### PR TITLE
Add support for templated dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ hubot>> Graphite Carbon Metrics: http://play.grafana.org/render/dashboard/solo/g
 - `hubot graf db graphite-carbon-metrics now-12hr` - Get a dashboard with a window of 12 hours ago to now
 - `hubot graf db graphite-carbon-metrics now-24hr now-12hr` - Get a dashboard with a window of 24 hours ago to 12 hours ago
 - `hubot graf db graphite-carbon-metrics:3 now-8d now-1d` - Get only the third panel of a particular dashboard with a window of 8 days ago to yesterday
+- `hubot graf db graphite-carbon-metrics host=carbon-a` - Get a templated dashboard with the `$host` parameter set to `carbon-a`
 - `hubot graf list` - Lists the available dashboards

--- a/test/grafana-test.coffee
+++ b/test/grafana-test.coffee
@@ -13,4 +13,7 @@ describe 'grafana', ->
     require('../src/grafana')(@robot)
 
   it 'registers a dashboard listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(| [A-Za-z0-9\-\+]+)?(| [A-Za-z0-9\-\+]+)?/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(.*)?/i)
+
+  it 'registers a list listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) list/i)


### PR DESCRIPTION
As promised.

I have implemented as I mentioned in #7 by splitting everything following the `slug:pid` part of the command depending on if there's a `=` in the word or not. All words which contain an `=` are added to the parameters list with `var-` prepended, and the ones not containing a `=` are assigned to the "from" and "to" fields in order, until they both are assigned. The rest is just discarded.

There's no URL encoding of the variables currently. I don't necessarily think that's a big problem, since stuff like spaces never should occur in a Graphite query, I would think.