### PR TITLE
[Patch] Fix help text, handle dashboard list issue

### DIFF
--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -13,7 +13,8 @@
 #   HUBOT_GRAFANA_API_KEY - API key for a particular user
 #
 # Commands:
-#   hubot graf db <dashboard slug>[:<panel id>][ <from clause>][ <to clause>] - Show grafana dashboard graphs
+#   hubot graf db <dashboard slug>[:<panel id>][ <template variables>][ <from clause>][ <to clause>] - Show grafana dashboard graphs
+#   hubot graf list - Lists all dashboards available
 #
 
 module.exports = (robot) ->
@@ -100,13 +101,27 @@ module.exports = (robot) ->
           link = "#{grafana_host}/dashboard/db/#{slug}/?panelId=#{panel.id}&fullscreen&from=#{timespan.from}&to=#{timespan.to}#{variables}"
           msg.send "#{formatTitleWithTemplate(panel.title, template_map)}: #{imageUrl} - #{link}"
 
-  robot.respond /(?:grafana|graph|graf) list/i, (msg) ->
+  robot.respond /(?:grafana|graph|graf) list$/i, (msg) ->
     callGrafana "search", (dashboards) ->
       robot.logger.debug dashboards
       msg.send "Available dashboards:"
 
-      for dashboard in dashboards
-        slug = dashboard.uri.replace /^db\//, ""
+      # Handle refactor done for version 2.0.2+
+      if dashboards.dashboards
+        list = dashboards.dashboards
+      else
+        list = dashboards
+
+      for dashboard in list
+
+        robot.logger.debug dashboard
+
+        # Handle refactor done for version 2.0.2+
+        if dashboard.uri
+          slug = dashboard.uri.replace /^db\//, ""
+        else
+          slug = dashboard.slug
+
         msg.send "- #{slug}: #{dashboard.title}"
 
   sendError = (message, msg) ->

--- a/test/grafana-test.coffee
+++ b/test/grafana-test.coffee
@@ -16,4 +16,4 @@ describe 'grafana', ->
     expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(.*)?/i)
 
   it 'registers a list listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) list/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) list$/i)


### PR DESCRIPTION
- Adds the `graf list` command to the help text (useful for users of `hubot-help` package)
- Handles an API discrepency on the `/search` route returning a 'result.dashboards` attribute on certain versions

/cc @Tenzer