### PR TITLE
Add support for using other regions than US

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Then add **hubot-grafana** to your `external-scripts.json`:
 - `HUBOT_GRAFANA_S3_ACCESS_KEY_ID` - Optional; Access key ID for S3
 - `HUBOT_GRAFANA_S3_SECRET_ACCESS_KEY` - Optional; Secret access key for S3
 - `HUBOT_GRAFANA_S3_PREFIX` - Optional; Bucket prefix (useful for shared buckets)
+- `HUBOT_GRAFANA_S3_REGION` - Optional; Bucket region (defaults to us-standard)
 
 Example:
 


### PR DESCRIPTION
This is an addition to #15 and adds support for specifying the region where the S3 bucket is created, but defaults to "us-standard" which is the [default setting](https://github.com/Automattic/knox#region) in Knox.

The URL printed with Hubot is different depending on the region, so we should instead use Knox's function to get the URL of the image we have just uploaded.