### PR TITLE
Count the panels we encounter to make sure we get the right panel

### DIFF
--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -107,12 +107,15 @@ module.exports = (robot) ->
           template_map['$' + template.name] = template.current.text
 
       # Return dashboard rows
+      panelNumber = 0
       for row in data.rows
         for panel in row.panels
           robot.logger.debug panel
 
+          panelNumber += 1
+
           # Skip if panel ID was specified and didn't match
-          if pid && pid != panel.id
+          if pid && pid != panelNumber
             continue
 
           # Build links for message sending


### PR DESCRIPTION
Going by panel ID doesn't work if a panel has been moved around the dashboard after it has been created. We should instead count how many we have seen and show the correct one when we see it (if we only are to show one panel).