### PR TITLE
Specify part of panel titles you want to see

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ hubot>> Graphite Carbon Metrics: http://play.grafana.org/render/dashboard/solo/g
 
 - `hubot graf db graphite-carbon-metrics` - Get all panels in the dashboard
 - `hubot graf db graphite-carbon-metrics:3` - Get only the third panel of a particular dashboard
+- `hubot graf db graphite-carbon-metrics:cpu` - Get only the panels containing "cpu" (case insensitive) in the title
 - `hubot graf db graphite-carbon-metrics now-12hr` - Get a dashboard with a window of 12 hours ago to now
 - `hubot graf db graphite-carbon-metrics now-24hr now-12hr` - Get a dashboard with a window of 24 hours ago to 12 hours ago
 - `hubot graf db graphite-carbon-metrics:3 now-8d now-1d` - Get only the third panel of a particular dashboard with a window of 8 days ago to yesterday


### PR DESCRIPTION
Some times it can be difficult to remember what number the panel was you wanted to get, but the title of the panel is likely much easier to remember, so let's use that.

This ie. adds support for doing commands such as `hubot graf db graphite-carbon-metrics:created` if you want the graph of metrics created in Carbon.

The title matching is case insensitive and just requires the search pattern to be somewhere in the title. It can currently only handle one word since the regex for the `graf db` command doesn't include spaces for the dashboard name, but I think that's okay.