### PR TITLE
Feature: Dashboard search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.node-version

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ hubot>> Graphite Carbon Metrics: http://play.grafana.org/render/dashboard/solo/g
 - `hubot graf db graphite-carbon-metrics now-12hr` - Get a dashboard with a window of 12 hours ago to now
 - `hubot graf db graphite-carbon-metrics now-24hr now-12hr` - Get a dashboard with a window of 24 hours ago to 12 hours ago
 - `hubot graf db graphite-carbon-metrics:3 now-8d now-1d` - Get only the third panel of a particular dashboard with a window of 8 days ago to yesterday
-- `hubot graf db graphite-carbon-metrics host=carbon-a` - Get a templated dashboard with the `$host` parameter set to `carbon-a`j
+- `hubot graf db graphite-carbon-metrics host=carbon-a` - Get a templated dashboard with the `$host` parameter set to `carbon-a`
 - `hubot graf list` - Lists the available dashboards
 - `hubot graf list production` - Lists all dashboards tagged `production`
 - `hubot graf search elb` - Search for dashboards that match `elb`

--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@ hubot>> Graphite Carbon Metrics: http://play.grafana.org/render/dashboard/solo/g
 - `hubot graf db graphite-carbon-metrics now-12hr` - Get a dashboard with a window of 12 hours ago to now
 - `hubot graf db graphite-carbon-metrics now-24hr now-12hr` - Get a dashboard with a window of 24 hours ago to 12 hours ago
 - `hubot graf db graphite-carbon-metrics:3 now-8d now-1d` - Get only the third panel of a particular dashboard with a window of 8 days ago to yesterday
-- `hubot graf db graphite-carbon-metrics host=carbon-a` - Get a templated dashboard with the `$host` parameter set to `carbon-a`
+- `hubot graf db graphite-carbon-metrics host=carbon-a` - Get a templated dashboard with the `$host` parameter set to `carbon-a`j
 - `hubot graf list` - Lists the available dashboards
+- `hubot graf list production` - Lists all dashboards tagged `production`
+- `hubot graf search elb` - Search for dashboards that match `elb`

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -143,7 +143,7 @@ module.exports = (robot) ->
             sendRobotResponse msg, title, imageUrl, link
 
   # Get a list of available dashboards
-  robot.respond /(?:grafana|graph|graf) list\s?(.*)?/i, (msg) ->
+  robot.respond /(?:grafana|graph|graf) list\s?(.+)?/i, (msg) ->
     if msg.match[1]
       tag = msg.match[1].trim()
       callGrafana "search?tag=#{tag}", (dashboards) ->
@@ -157,7 +157,7 @@ module.exports = (robot) ->
         sendDashboardList dashboards, response, msg
 
   # Search dashboards
-  robot.respond /(?:grafana|graph|graf) search (.*)/i, (msg) ->
+  robot.respond /(?:grafana|graph|graf) search (.+)/i, (msg) ->
     query = msg.match[2].trim()
     robot.logger.debug query
     callGrafana "search?query=#{query}", (dashboards) ->

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -24,7 +24,8 @@
 #
 # Commands:
 #   hubot graf db <dashboard slug>[:<panel id>][ <template variables>][ <from clause>][ <to clause>] - Show grafana dashboard graphs
-#   hubot graf list - Lists all dashboards available
+#   hubot graf list <tag> - Lists all dashboards available (optional: <tag>)
+#   hubot graf search <keyword> - Search available dashboards by <keyword>
 #
 
 crypto  = require 'crypto'
@@ -142,31 +143,52 @@ module.exports = (robot) ->
             sendRobotResponse msg, title, imageUrl, link
 
   # Get a list of available dashboards
-  robot.respond /(?:grafana|graph|graf) list$/i, (msg) ->
-    callGrafana 'search', (dashboards) ->
+  robot.respond /(?:grafana|graph|graf) list\s?(.*)?/i, (msg) ->
+    if msg.match[1]
+      tag = msg.match[1].trim()
+      callGrafana "search?tag=#{tag}", (dashboards) ->
+        robot.logger.debug dashboards
+        response = "Dashboards tagged `#{tag}`:\n"
+        sendDashboardList dashboards, response, msg
+    else
+      callGrafana 'search', (dashboards) ->
+        robot.logger.debug dashboards
+        response = "Available dashboards:\n"
+        sendDashboardList dashboards, response, msg
+
+  # Search dashboards
+  robot.respond /(?:grafana|graph|graf) search (.*)/i, (msg) ->
+    query = msg.match[2].trim()
+    robot.logger.debug query
+    callGrafana "search?query=#{query}", (dashboards) ->
       robot.logger.debug dashboards
-      response = "Available dashboards:\n"
+      response = "Dashboards matching `#{query}`:\n"
+      sendDashboardList dashboards, response, msg
 
+  # Send Dashboard list
+  sendDashboardList = (dashboards, response, msg) ->
+    # Handle refactor done for version 2.0.2+
+    if dashboards.dashboards
+      list = dashboards.dashboards
+    else
+      list = dashboards
+
+    robot.logger.debug list
+    unless list.length > 0
+      return
+
+    for dashboard in list
       # Handle refactor done for version 2.0.2+
-      if dashboards.dashboards
-        list = dashboards.dashboards
+      if dashboard.uri
+        slug = dashboard.uri.replace /^db\//, ''
       else
-        list = dashboards
+        slug = dashboard.slug
+      response = response + "- #{slug}: #{dashboard.title}\n"
 
-      robot.logger.debug list
+    # Remove trailing newline
+    response.trim()
 
-      for dashboard in list
-        # Handle refactor done for version 2.0.2+
-        if dashboard.uri
-          slug = dashboard.uri.replace /^db\//, ''
-        else
-          slug = dashboard.slug
-        response = response + "- #{slug}: #{dashboard.title}\n"
-
-      # Remove trailing newline
-      response.trim()
-
-      msg.send response
+    msg.send response
 
   # Handle generic errors
   sendError = (message, msg) ->

--- a/test/grafana-test.coffee
+++ b/test/grafana-test.coffee
@@ -16,4 +16,7 @@ describe 'grafana', ->
     expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(.*)?/i)
 
   it 'registers a list listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) list\s?(.*)?/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) list\s?(.+)?/i)
+
+  it 'registers a search listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) search (.+)/i)

--- a/test/grafana-test.coffee
+++ b/test/grafana-test.coffee
@@ -16,4 +16,4 @@ describe 'grafana', ->
     expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(.*)?/i)
 
   it 'registers a list listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) list$/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) list\s?(.*)?/i)


### PR DESCRIPTION
Related to #20

There is an API endpoint that accepts a query string to search available dashboards. Rather than re-invent the wheel, this adds two new calls to leverage that endpoint. This prevents a user from haivng to always use `hubot graf list` to get the entire list of the dashboards in order to query one of them.

- `hubot graf search <term>` will translate to `/api/search/?query=<term>` and return dashboards that have titles that match specified term
- `hubot graf list <tag>` will translate to `/api/search/?tag=<tag>` and return dashboards that match the specified tag