### PR TITLE
make time range configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Then add **hubot-grafana** to your `external-scripts.json`:
 
 - `HUBOT_GRAFANA_HOST` - Host for your Grafana 2.0 install, e.g. 'http://play.grafana.org'
 - `HUBOT_GRAFANA_API_KEY` - API key for a particular user
+- `HUBOT_GRAFANA_QUERY_TIME_RANGE` - Optional; Default time range for queries (defaults to 6h)
 - `HUBOT_GRAFANA_S3_BUCKET` - Optional; Name of the S3 bucket to copy the graph into
 - `HUBOT_GRAFANA_S3_ACCESS_KEY_ID` - Optional; Access key ID for S3
 - `HUBOT_GRAFANA_S3_SECRET_ACCESS_KEY` - Optional; Secret access key for S3
@@ -35,6 +36,7 @@ Example:
 ```
 export HUBOT_GRAFANA_HOST=http://play.grafana.org
 export HUBOT_GRAFANA_API_KEY=abcd01234deadbeef01234
+export HUBOT_GRAFANA_QUERY_TIME_RANGE=1h
 export HUBOT_GRAFANA_S3_BUCKET=mybucket
 export HUBOT_GRAFANA_S3_ACCESS_KEY_ID=ABCDEF123456XYZ
 export HUBOT_GRAFANA_S3_SECRET_ACCESS_KEY=aBcD01234dEaDbEef01234

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -12,6 +12,7 @@
 # Configuration:
 #   HUBOT_GRAFANA_HOST - Host for your Grafana 2.0 install, e.g. 'http://play.grafana.org'
 #   HUBOT_GRAFANA_API_KEY - API key for a particular user (leave unset if unauthenticated)
+#   HUBOT_GRAFANA_QUERY_TIME_RANGE - Optional; Default time range for queries (defaults to 6h)
 #   HUBOT_GRAFANA_S3_BUCKET - Optional; Name of the S3 bucket to copy the graph into
 #   HUBOT_GRAFANA_S3_ACCESS_KEY_ID - Optional; Access key ID for S3
 #   HUBOT_GRAFANA_S3_SECRET_ACCESS_KEY - Optional; Secret access key for S3
@@ -36,6 +37,7 @@ module.exports = (robot) ->
   # Various configuration options stored in environment variables
   grafana_host = process.env.HUBOT_GRAFANA_HOST
   grafana_api_key = process.env.HUBOT_GRAFANA_API_KEY
+  grafana_query_time_range = process.env.HUBOT_GRAFANA_QUERY_TIME_RANGE or '6h'
   s3_bucket = process.env.HUBOT_GRAFANA_S3_BUCKET
   s3_access_key = process.env.HUBOT_GRAFANA_S3_ACCESS_KEY_ID
   s3_secret_key = process.env.HUBOT_GRAFANA_S3_SECRET_ACCESS_KEY
@@ -48,7 +50,7 @@ module.exports = (robot) ->
     slug = msg.match[1].trim()
     remainder = msg.match[2]
     timespan = {
-      from: 'now-6h'
+      from: "now-#{grafana_query_time_range}"
       to: 'now'
     }
     variables = ''


### PR DESCRIPTION
The default time range is hard coded to 6 hours. We typically use a different time range by default in our graphs.

This introduces an optional environment variable `HUBOT_GRAFANA_QUERY_TIME_RANGE` to adjust this.