### PR TITLE
Update to use panel ID's from Grafana

### DIFF
--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -128,15 +128,12 @@ module.exports = (robot) ->
               template_map['$' + template.name] = template.current.text
 
       # Return dashboard rows
-      panelNumber = 0
       for row in data.rows
         for panel in row.panels
           robot.logger.debug panel
 
-          panelNumber += 1
-
           # Skip if panel ID was specified and didn't match
-          if pid && pid != panelNumber
+          if pid && pid != panel.id
             continue
 
           # Skip if panel name was specified any didn't match


### PR DESCRIPTION
Previously it was iterating all panels and assuming their ID's were in the order iterated, but they actually all contain ID's and reorganizing the dashboard will give wildly different graphs than expected before this fix.

This is Grafana 2.6.0. Here's some panel JSON:

```js
{ aliasColors: {},
  bars: false,
  datasource: null,
  editable: true,
  error: false,
  fill: 0,
  grid:
   { leftLogBase: 1,
     leftMax: null,
     leftMin: null,
     rightLogBase: 1,
     rightMax: null,
     rightMin: null,
     threshold1: null,
     threshold1Color: 'rgba(216, 200, 27, 0.27)',
     threshold2: null,
     threshold2Color: 'rgba(234, 112, 112, 0.22)' },
  id: 13,
  legend:
   { avg: false,
     current: true,
     max: false,
     min: false,
     show: true,
     total: false,
     values: true },
  lines: true,
  linewidth: 1,
  links: [],
  nullPointMode: 'connected',
  percentage: false,
  pointradius: 5,
  points: false,
  renderer: 'flot',
  seriesOverrides: [],
  span: 6,
  stack: false,
  steppedLine: false,
  targets:
   [ { refId: 'A',
       target: 'aliasByMetric(sitespeed.io.https.www_chess_com.slash.rules.*)',
       textEditor: true } ],
  timeFrom: null,
  timeShift: null,
  title: 'Rule score',
  tooltip: { shared: true, value_type: 'cumulative' },
  type: 'graph',
  'x-axis': true,
  'y-axis': true,
  y_formats: [ 'short', 'short' ] }
```