### PR TITLE
Allow panel retrieval by API identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Get a single panel of a dashboard. In this example, only the third panel would b
 hubot graf db graphite-carbon-metrics:3
 ```
 
+If you want to refer to the API Panel ID, use the `:panel-<identifier>` format to retrieve it. These will not change when the dashboard is re-arranged.
+
+```
+hubot graf db graphite-carbon-metrics:panel-8
+```
+
 Get all panels matching a particular title (case insensitive) in a dashboard. In this case, only panels containing `cpu` would be returned.
 
 ```

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -3,7 +3,7 @@
 #
 #   Examples:
 #   - `hubot graf db graphite-carbon-metrics` - Get all panels in the dashboard
-#   - `hubot graf db graphite-carbon-metrics:3` - Get only the third panel, from right to left, of a particular dashboard
+#   - `hubot graf db graphite-carbon-metrics:3` - Get only the third panel, from left to right, of a particular dashboard
 #   - `hubot graf db graphite-carbon-metrics:panel-8` - Get only the panel of a particular dashboard with the ID of 8
 #   - `hubot graf db graphite-carbon-metrics:cpu` - Get only the panels containing "cpu" (case insensitive) in the title
 #   - `hubot graf db graphite-carbon-metrics now-12hr` - Get a dashboard with a window of 12 hours ago to now

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -3,7 +3,8 @@
 #
 #   Examples:
 #   - `hubot graf db graphite-carbon-metrics` - Get all panels in the dashboard
-#   - `hubot graf db graphite-carbon-metrics:3` - Get only the third panel of a particular dashboard
+#   - `hubot graf db graphite-carbon-metrics:3` - Get only the third panel, from right to left, of a particular dashboard
+#   - `hubot graf db graphite-carbon-metrics:panel-8` - Get only the panel of a particular dashboard with the ID of 8
 #   - `hubot graf db graphite-carbon-metrics:cpu` - Get only the panels containing "cpu" (case insensitive) in the title
 #   - `hubot graf db graphite-carbon-metrics now-12hr` - Get a dashboard with a window of 12 hours ago to now
 #   - `hubot graf db graphite-carbon-metrics now-24hr now-12hr` - Get a dashboard with a window of 24 hours ago to 12 hours ago
@@ -58,17 +59,22 @@ module.exports = (robot) ->
     }
     variables = ''
     template_params = []
-    pid = false
+    visualPanelId = false
+    apiPanelId = false
     pname = false
 
     # Parse out a specific panel
     if /\:/.test slug
       parts = slug.split(':')
       slug = parts[0]
-      pid = parseInt parts[1], 10
-      if isNaN pid
-        pid = false
+      visualPanelId = parseInt parts[1], 10
+      if isNaN visualPanelId
+        visualPanelId = false
         pname = parts[1].toLowerCase()
+      if /panel-[0-9]+/.test pname
+        parts = pname.split('panel-')
+        apiPanelId = parseInt parts[1], 10
+        pname = false
 
     # Check if we have any extra fields
     if remainder
@@ -90,7 +96,8 @@ module.exports = (robot) ->
     robot.logger.debug timespan
     robot.logger.debug variables
     robot.logger.debug template_params
-    robot.logger.debug pid
+    robot.logger.debug visualPanelId
+    robot.logger.debug apiPanelId
     robot.logger.debug pname
 
     # Call the API to get information about this dashboard
@@ -135,8 +142,12 @@ module.exports = (robot) ->
 
           panelNumber += 1
 
-          # Skip if panel ID was specified and didn't match
-          if pid && pid != panelNumber
+          # Skip if visual panel ID was specified and didn't match
+          if visualPanelId && visualPanelId != panelNumber
+            continue
+
+          # Skip if API panel ID was specified and didn't match
+          if apiPanelId && apiPanelId != panel.id
             continue
 
           # Skip if panel name was specified any didn't match

--- a/test/grafana-test.coffee
+++ b/test/grafana-test.coffee
@@ -85,6 +85,20 @@ describe 'grafana', ->
         [ 'hubot', "Dashboards matching `elasticsearch`:\n- elasticsearch-metrics: Elasticsearch Metrics\n"]
       ]
 
+  context 'ask hubot to return a specific panel by API ID', ->
+    beforeEach (done) ->
+      nock('http://play.grafana.org')
+        .get('/api/dashboards/db/grafana-play-home')
+        .replyWithFile(200, __dirname + '/fixtures/dashboard-grafana-play-home.json')
+      room.user.say 'alice', 'hubot graf db grafana-play-home:panel-8'
+      setTimeout done, 100
+
+    it 'hubot should respond with a matching dashboard', ->
+      expect(room.messages).to.eql [
+        [ 'alice', 'hubot graf db grafana-play-home:panel-8' ]
+        [ 'hubot', "Graphite examples: http://play.grafana.org/render/dashboard-solo/db/grafana-play-home/?panelId=8&width=1000&height=500&from=now-6h&to=now - http://play.grafana.org/dashboard/db/grafana-play-home/?panelId=8&fullscreen&from=now-6h&to=now"]
+      ]
+
   context 'ask hubot to return a specific panel by visual ID', ->
     beforeEach (done) ->
       nock('http://play.grafana.org')


### PR DESCRIPTION
Fixes #26.

This should allow a user to append a `panel-<id>` to lock a particular panel to its identifier rather than where it is visually on a dashboard. I updated the tests and it appears to work, but I'd appreciate some real-world testing with it before I merge it. :smile:

/cc @klynch @torkelo @Tenzer @ShonM