### PR TITLE
Improved formatting for Slack clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Recommended if you use a service such as Slack or HipChat. You can omit all of t
 
 Graphs are downloaded to the box running **hubot-grafana** and then uploaded to S3 with world-readable rights, so you do not have to do anything special to your S3 bucket in order to serve the graph images suitable for Slack or HipChat.  E.g., you do not have to set up web hosting for your S3 bucket.
 
-
 | Configuration Variable               | Required | Description                |
 | ------------------------------------ | -------- | -------------------------- |
 | `HUBOT_GRAFANA_S3_BUCKET`            | **Yes**  | Name of the S3 bucket to copy the graph into |
@@ -51,7 +50,6 @@ Graphs are downloaded to the box running **hubot-grafana** and then uploaded to 
 | `HUBOT_GRAFANA_S3_ENDPOINT`          | No       | Endpoint of the S3 API (useful for S3 compatible API, defaults to s3.amazonaws.com) |
 | `HUBOT_GRAFANA_S3_PORT`              | No       | Port of the S3 endpoint
 | `HUBOT_GRAFANA_S3_STYLE`             | No       | Bucket style of the S3 endpoint 'virtualHosted' or 'path' defaults to 'virtualHosted' |
-
 
 You most likely want to add an S3 Life Cycle Configuration that will "Permanently Delete" the graphs after 1 hour or 1 day, as appropriate for your organization.
 
@@ -87,7 +85,6 @@ EC2 IAM Roles will _not_ be used.  In order for your **hubot-grafana** to be all
     ]
 }
 ```
-
 
 ### Example Configuration
 

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -25,6 +25,11 @@
 #   "knox": "^0.9.2"
 #   "request": "~2"
 #
+# Notes:
+#   If you want to use the Slack adapter's "attachment" formatting:
+#     hubot: v2.7.2+
+#     hubot-slack: 4.0+
+#
 # Commands:
 #   hubot graf db <dashboard slug>[:<panel id>][ <template variables>][ <from clause>][ <to clause>] - Show grafana dashboard graphs
 #   hubot graf list <tag> - Lists all dashboards available (optional: <tag>)
@@ -228,7 +233,26 @@ module.exports = (robot) ->
 
   # Send robot response
   sendRobotResponse = (msg, title, image, link) ->
-    msg.send "#{title}: #{image} - #{link}"
+    switch robot.adapterName
+      # Slack
+      when 'slack'
+        msg.send {
+          attachments: [
+            {
+              fallback: "#{title}: #{image} - #{link}",
+              title: title,
+              title_link: link,
+              image_url: image
+            }
+          ],
+          unfurl_links: false
+        }
+      # Hipchat
+      when 'hipchat'
+        msg.send "#{title}: #{link} - #{image}"
+      # Everything else
+      else
+        msg.send "#{title}: #{image} - #{link}"
 
   # Call off to Grafana
   callGrafana = (url, callback) ->


### PR DESCRIPTION
This package has always been a bit noisy and relied on Slack's native "unfurling" of links. The `robot.adapterName` property has been exposed for a while (2014), so it is likely a safe bet to leverage some of the more advanced features of that adapter.

## Before

![screen shot 2017-01-16 at 10 08 54 pm](https://cloud.githubusercontent.com/assets/80459/22007494/b1c09e56-dc38-11e6-8661-a976502cceff.png)

## After

![screen shot 2017-01-16 at 10 10 29 pm](https://cloud.githubusercontent.com/assets/80459/22007477/a12b9dca-dc38-11e6-96ca-38b7356c9934.png)

---

- Fixes #27 by making the changes there less needed.