### PR TITLE
Allow function hooks to upload dashboard images to multiple services

### DIFF
--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -305,7 +305,7 @@ module.exports = (robot) ->
 
         headers = {
           'Content-Length' : body.length,
-          'Content-Type'   : res.headers['content_type'],
+          'Content-Type'   : res.headers['content-type'],
           'x-amz-acl'      : 'public-read',
           'encoding'       : null
         }

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -289,22 +289,7 @@ module.exports = (robot) ->
   uploadPath = () ->
     prefix = s3_prefix || 'grafana'
     "#{prefix}/#{crypto.randomBytes(20).toString('hex')}.png"
-
-  # Fetch an image from provided URL, upload it to S3, returning the resulting URL
-  uploadChart = (msg, title, url, link, site) ->
-    if grafana_api_key
-        requestHeaders =
-          encoding: null,
-          auth:
-            bearer: grafana_api_key
-      else
-        requestHeaders =
-          encoding: null
-
-    request url, requestHeaders, (err, res, body) ->
-      robot.logger.debug "Uploading file: #{body.length} bytes, content-type[#{res.headers['content-type']}]"
-      uploadTo[site()](msg, title, link, body, res)
-
+  
   uploadTo =
     's3': (msg, title, link, body, res) ->
       client = knox.createClient {
@@ -360,3 +345,18 @@ module.exports = (robot) ->
               robot.logger.error err
               msg.send "#{title} - [Upload Error] - #{link}"
           )
+      
+  # Fetch an image from provided URL, upload it to S3, returning the resulting URL
+  uploadChart = (msg, title, url, link, site) ->
+    if grafana_api_key
+        requestHeaders =
+          encoding: null,
+          auth:
+            bearer: grafana_api_key
+      else
+        requestHeaders =
+          encoding: null
+
+    request url, requestHeaders, (err, res, body) ->
+      robot.logger.debug "Uploading file: #{body.length} bytes, content-type[#{res.headers['content-type']}]"
+      uploadTo[site()](msg, title, link, body, res)

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -55,7 +55,13 @@ module.exports = (robot) ->
   s3_region = process.env.HUBOT_GRAFANA_S3_REGION or 'us-standard'
   s3_port = process.env.HUBOT_GRAFANA_S3_PORT if process.env.HUBOT_GRAFANA_S3_PORT
   slack_url = process.env.HUBOT_SLACK_URL
-  site = 's3' if (s3_bucket && s3_access_key && s3_secret_key) else if (slack_url && robot.adapterName == 'slack') else ''
+  site = () ->
+    if (s3_bucket && s3_access_key && s3_secret_key)
+      's3'
+    else if (slack_url && robot.adapterName == 'slack') 
+      'slack'
+    else
+      ''
   isUploadSupported = site != ''
 
   # Get a specific dashboard with options
@@ -297,7 +303,7 @@ module.exports = (robot) ->
 
     request url, requestHeaders, (err, res, body) ->
       robot.logger.debug "Uploading file: #{body.length} bytes, content-type[#{res.headers['content-type']}]"
-      uploadTo[site](msg, title, link, body, res)
+      uploadTo[site()](msg, title, link, body, res)
 
   uploadTo =
     's3': (msg, title, link, body, res) ->

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -327,7 +327,8 @@ module.exports = (robot) ->
             robot.logger.debug res
             robot.logger.error "Upload Error Code: #{res.statusCode}"
             msg.send "#{title} - [Upload Error] - #{link}"
-        req.end(body);
+
+        req.end body
 
     'slack': (msg, title, grafanaDashboardRequest, link) ->
       testAuthData = 

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -55,14 +55,15 @@ module.exports = (robot) ->
   s3_region = process.env.HUBOT_GRAFANA_S3_REGION or 'us-standard'
   s3_port = process.env.HUBOT_GRAFANA_S3_PORT if process.env.HUBOT_GRAFANA_S3_PORT
   slack_url = process.env.HUBOT_SLACK_URL
+  slack_token = process.env.HUBOT_SLACK_TOKEN
   site = () ->
     if (s3_bucket && s3_access_key && s3_secret_key)
       's3'
-    else if (slack_url && robot.adapterName == 'slack') 
+    else if (slack_url && slack_token && robot.adapterName == 'slack') 
       'slack'
     else
       ''
-  isUploadSupported = site != ''
+  isUploadSupported = site() != ''
 
   # Get a specific dashboard with options
   robot.respond /(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(.*)?/i, (msg) ->
@@ -337,7 +338,7 @@ module.exports = (robot) ->
         url: slack_url + '/api/files.upload'
         formData:
           channels: msg.envelope.room
-          token: hubot_slack_token
+          token: slack_token
           # How could I use a readable stream directly from body?
           file: fs.createReadStream tempFile         
           }, (err, httpResponse, body) ->
@@ -345,7 +346,7 @@ module.exports = (robot) ->
               robot.logger.error err
               msg.send "#{title} - [Upload Error] - #{link}"
           )
-      
+
   # Fetch an image from provided URL, upload it to S3, returning the resulting URL
   uploadChart = (msg, title, url, link, site) ->
     if grafana_api_key


### PR DESCRIPTION
This `PR` has refactoring so it may be not accepted. The main goal is to provide flexibility when extending uploading images methods. Image upload is a key concept in this plugin. The idea is to extend or easily add new methods for uploading images to different services.

`fetchAndUpload` was removed. A dictionary of functions [`uploadTo`](https://github.com/gentunian/hubot-grafana/blob/master/src/grafana.coffee#L294) was introduced. It should be extended by adding a value into the object, then `uploadTo["myService"]` will be the function responsible of uploading a dashboard image to "myService".

All this logic is encapsulated within the [`sendDashboarChart`](https://github.com/gentunian/hubot-grafana/blob/master/src/grafana.coffee#L178). This function will [`uploadChart`](https://github.com/gentunian/hubot-grafana/blob/master/src/grafana.coffee#L351) or send the grafana link.

It's worth to mention that a better way to [determine which service should be used](https://github.com/gentunian/hubot-grafana/blob/master/src/grafana.coffee#L59) could be written.

S3 test were impossible for me to make. Tests were done when absence and presence of Slack `URL` and worked correctly. 