### PR TITLE
supported BearyChat

### DIFF
--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -276,6 +276,21 @@ module.exports = (robot) ->
       # Hipchat
       when 'hipchat'
         msg.send "#{title}: #{link} - #{image}"
+      # BearyChat
+      when 'bearychat'
+        robot.emit 'bearychat.attachment', {
+          message:
+            room: msg.envelope.room
+          text: "[#{title}](#{link})"
+          attachments: [
+            {
+              fallback: "#{title}: #{image} - #{link}",
+              images: [
+                url: image
+              ]
+            }
+          ],
+        }
       # Everything else
       else
         msg.send "#{title}: #{image} - #{link}"


### PR DESCRIPTION
BearyChat (https://bearychat.com) is a Slack alternative service. This pull request supported BearyChat just like Slack.
Please review, thanks.