### PR TITLE
Add file title to Slack uploads

### DIFF
--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -372,6 +372,9 @@ module.exports = (robot) ->
         req.end body
 
     'slack': (msg, title, grafanaDashboardRequest, link) ->
+      unless title?
+        title = 'Upload'
+
       testAuthData =
         url: 'https://slack.com/api/auth.test'
         formData:

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -372,9 +372,6 @@ module.exports = (robot) ->
         req.end body
 
     'slack': (msg, title, grafanaDashboardRequest, link) ->
-      unless title?
-        title = 'Upload'
-
       testAuthData =
         url: 'https://slack.com/api/auth.test'
         formData:
@@ -472,6 +469,10 @@ module.exports = (robot) ->
     else
       requestHeaders =
         encoding: null
+
+    # Default title if none provided
+    if !title
+      title = 'Image'
 
     # Pass this function along to the "registered" services that uploads the image.
     # The function will donwload the .png image(s) dashboard. You must pass this

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -389,10 +389,12 @@ module.exports = (robot) ->
             uploadData =
               url: slack_url + '/api/files.upload'
               formData:
+                title: "#{title}"
                 channels: msg.envelope.room
                 token: slack_token
                 # grafanaDashboardRequest() is the method that downloads the .png
                 file: grafanaDashboardRequest()
+                filetype: 'png'
 
             # Try to upload the image to slack else pass the link over
             request.post uploadData, (err, httpResponse, body) ->


### PR DESCRIPTION
Currently shows the query string, which isn't terribly useful.

### Before

![before](https://user-images.githubusercontent.com/80459/38880465-6be6b988-422b-11e8-80c9-0414f3d16e43.png)

### After

![after](https://user-images.githubusercontent.com/80459/38880466-6bf418b2-422b-11e8-99fa-e60e68d5b7fc.png)

