### PR TITLE
Add option to configure Grafana Host and API key per room

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ Then add **hubot-grafana** to your `external-scripts.json`:
 
 | Configuration Variable           | Required | Description                    |
 | -------------------------------- | -------- | ------------------------------ |
-| `HUBOT_GRAFANA_HOST`             | **Yes**  | Host for your Grafana 2.x install, e.g. `http://play.grafana.org` |
-| `HUBOT_GRAFANA_API_KEY`          | _Yes^_   | Grafana API key (This can be "Viewer" role.) |
+| `HUBOT_GRAFANA_HOST`             | **Yes^**  | Host for your Grafana 2.x install, e.g. `http://play.grafana.org` |
+| `HUBOT_GRAFANA_API_KEY`          | _Yes^^_   | Grafana API key (This can be "Viewer" role.) |
+| `HUBOT_GRAFANA_PER_ROOM`         | No       | Allow per room Grafana Host & API key configuration |
 | `HUBOT_GRAFANA_QUERY_TIME_RANGE` | No       | Default time range for queries (defaults to 6h) |
 | `HUBOT_GRAFANA_DEFAULT_WIDTH`    | No       | Default width for rendered images (defaults to 1000) |
 | `HUBOT_GRAFANA_DEFAULT_HEIGHT`   | No       | Default height for rendered images (defaults to 500) |
-^ _Not required for `auth.anonymous` Grafana configurations. All other authentication models will require a user-specific API key._
+^ _Not required when `HUBOT_GRAFANA_PER_ROOM` is set to 1._
+
+^^ _Not required for `auth.anonymous` Grafana configurations. All other authentication models will require a user-specific API key._
+
 
 ### Image Hosting Configuration
 
@@ -140,4 +144,13 @@ Similarly, you can search the list of dashboards. In this example, return all da
 
 ```
 hubot graf search elb
+```
+
+### Per room configuration
+
+When `HUBOT_GRAFANA_PER_ROOM` is set to '1' the following commands configure the Grafana Host and API key for the room in which the commands are issued.
+
+```
+hubot graf set host http://play.grafana.org
+hubot graf set api_key abcd01234deadbeef01234
 ```

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -110,7 +110,7 @@ module.exports = (robot) ->
       robot.brain.set('grafana_' + msg.match[1] + '_' + context, msg.match[2])
       msg.send "Value set for #{msg.match[1]}"
     else
-      msg.send "Not configured to use multiple configurations"
+      sendError 'Set HUBOT_GRAFANA_PER_ROOM=1 to use multiple configurations.', msg
 
   # Get a specific dashboard with options
   robot.respond /(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(.*)?/i, (msg) ->
@@ -130,7 +130,7 @@ module.exports = (robot) ->
       height: process.env.HUBOT_GRAFANA_DEFAULT_HEIGHT or 500
     endpoint = get_grafana_endpoint(msg)
     if not endpoint
-      msg.send "no grafana endpoint configured"
+      sendError 'No Grafana endpoint configured.', msg
       return
     # Parse out a specific panel
     if /\:/.test slug
@@ -247,7 +247,7 @@ module.exports = (robot) ->
   robot.respond /(?:grafana|graph|graf) list\s?(.+)?/i, (msg) ->
     endpoint = get_grafana_endpoint(msg)
     if not endpoint
-      msg.send "no grafana endpoint configured"
+      sendError 'No Grafana endpoint configured.', msg
     else if msg.match[1]
       tag = msg.match[1].trim()
       callGrafana endpoint, "search?type=dash-db&tag=#{tag}", (dashboards) ->
@@ -266,7 +266,7 @@ module.exports = (robot) ->
     endpoint = get_grafana_endpoint(msg)
     robot.logger.debug query
     if not endpoint
-      msg.send "no grafana endpoint configured"
+      sendError 'No Grafana endpoint configured.', msg
       return
     callGrafana endpoint, "search?type=dash-db&query=#{query}", (dashboards) ->
       robot.logger.debug dashboards
@@ -277,7 +277,7 @@ module.exports = (robot) ->
   robot.respond /(?:grafana|graph|graf) alerts\s?(.+)?/i, (msg) ->
     endpoint = get_grafana_endpoint(msg)
     if not endpoint
-      msg.send "no grafana endpoint configured"
+      sendError 'No Grafana endpoint configured.', msg
       return
     # all alerts of a specific type
     if msg.match[1]
@@ -298,7 +298,7 @@ module.exports = (robot) ->
     alertId = msg.match[2]
     endpoint = get_grafana_endpoint(msg)
     if not endpoint
-      msg.send "no grafana endpoint configured"
+      sendError 'No Grafana endpoint configured.', msg
       return
     postGrafana endpoint, "alerts/#{alertId}/pause", {'paused': paused}, (result) ->
       robot.logger.debug result
@@ -311,7 +311,7 @@ module.exports = (robot) ->
     paused = msg.match[1] == 'pause'
     endpoint = get_grafana_endpoint(msg)
     if not endpoint
-      msg.send "no grafana endpoint configured"
+      sendError 'No Grafana endpoint configured.', msg
       return
     postGrafana endpoint, 'admin/pause-all-alerts', {'paused': paused}, (result) ->
       robot.logger.debug result

--- a/test/per-room-configuration-test.coffee
+++ b/test/per-room-configuration-test.coffee
@@ -1,0 +1,84 @@
+Helper = require('hubot-test-helper')
+chai = require 'chai'
+sinon = require 'sinon'
+chai.use require 'sinon-chai'
+nock = require('nock')
+
+helper = new Helper('./../src/grafana.coffee')
+
+expect = chai.expect
+
+describe 'per room configuration', ->
+  room_one = null
+
+  beforeEach ->
+    process.env.HUBOT_GRAFANA_HOST = 'http://play.grafana.org'
+    process.env.HUBOT_GRAFANA_PER_ROOM = '1'
+    room_one = helper.createRoom()
+    nock.disableNetConnect()
+
+    @robot =
+      respond: sinon.spy()
+      hear: sinon.spy()
+
+    require('../src/grafana')(@robot)
+
+  afterEach ->
+    room_one.destroy()
+    nock.cleanAll()
+    delete process.env.HUBOT_GRAFANA_HOST
+    delete process.env.HUBOT_GRAFANA_PER_ROOM
+
+  context 'ensure configuration listener is registered', ->
+    it 'register configuration listener', ->
+      expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) set (host|api_key) (.+)/i)
+
+  context 'ask hubot to configure grafana host', ->
+    beforeEach (done) ->
+      room_one.user.say 'alice', 'hubot graf set host http://play.grafana.org'
+      setTimeout done, 100
+
+    it 'hubot should respond it has configured the host', ->
+      expect(room_one.messages).to.eql [
+        [ 'alice', 'hubot graf set host http://play.grafana.org' ]
+        [ 'hubot', "Value set for host"]
+      ]
+
+  context 'ask hubot to configure grafana api_key', ->
+    beforeEach (done) ->
+      room_one.user.say 'alice', 'hubot graf set api_key AABBCC'
+      setTimeout done, 100
+
+    it 'hubot should respond it has configured the api_key', ->
+      expect(room_one.messages).to.eql [
+        [ 'alice', 'hubot graf set api_key AABBCC' ]
+        [ 'hubot', "Value set for api_key"]
+      ]
+
+  context 'ask hubot to list dashboards filterd by tag', ->
+    beforeEach (done) ->
+      room_one.user.say 'alice', 'hubot graf list demo'
+      setTimeout done, 100
+
+    it 'hubot should respond that grafana endpoint is not configured', ->
+      expect(room_one.messages).to.eql [
+        [ 'alice', 'hubot graf list demo' ]
+        [ 'hubot', "no grafana endpoint configured"]
+      ]
+
+  context 'ask hubot to configure host and then list dashboards filterd by tag', ->
+    beforeEach (done) ->
+      nock('http://play.grafana.org')
+        .get('/api/search?type=dash-db&tag=demo')
+        .replyWithFile(200, __dirname + '/fixtures/v5/search-tag.json')
+      room_one.user.say 'alice', 'hubot graf set host http://play.grafana.org'
+      room_one.user.say 'alice', 'hubot graf list demo'
+      setTimeout done, 1000
+
+    it 'hubot should respond that grafana is configured and then with a list of dashboards with tag', ->
+      expect(room_one.messages).to.eql [
+        [ 'alice', 'hubot graf set host http://play.grafana.org' ]
+        [ 'alice', 'hubot graf list demo' ]
+        [ 'hubot', "Value set for host"]
+        [ 'hubot', "Dashboards tagged `demo`:\n- alerting: Alerting\n- annotations: Annotations\n- big-dashboard: Big Dashboard\n- graph-styles: Graph styles\n- templating: Templating\n"]
+      ]

--- a/test/per-room-configuration-test.coffee
+++ b/test/per-room-configuration-test.coffee
@@ -63,7 +63,7 @@ describe 'per room configuration', ->
     it 'hubot should respond that grafana endpoint is not configured', ->
       expect(room_one.messages).to.eql [
         [ 'alice', 'hubot graf list demo' ]
-        [ 'hubot', "no grafana endpoint configured"]
+        [ 'hubot', "No Grafana endpoint configured."]
       ]
 
   context 'ask hubot to configure host and then list dashboards filterd by tag', ->

--- a/test/static-configuration-test.coffee
+++ b/test/static-configuration-test.coffee
@@ -1,0 +1,54 @@
+Helper = require('hubot-test-helper')
+chai = require 'chai'
+sinon = require 'sinon'
+chai.use require 'sinon-chai'
+nock = require('nock')
+
+helper = new Helper('./../src/grafana.coffee')
+
+expect = chai.expect
+
+describe 'static configuration', ->
+  room = null
+
+  beforeEach ->
+    process.env.HUBOT_GRAFANA_HOST = 'http://play.grafana.org'
+    room = helper.createRoom()
+    nock.disableNetConnect()
+
+    @robot =
+      respond: sinon.spy()
+      hear: sinon.spy()
+
+    require('../src/grafana')(@robot)
+
+  afterEach ->
+    room.destroy()
+    nock.cleanAll()
+    delete process.env.HUBOT_GRAFANA_HOST
+
+  context 'ensure configuration listener is registered', ->
+    it 'register configuration listener', ->
+      expect(@robot.respond).to.have.been.calledWith(/(?:grafana|graph|graf) set (host|api_key) (.+)/i)
+
+  context 'ask hubot to configure grafana host', ->
+    beforeEach (done) ->
+      room.user.say 'alice', 'hubot graf set host http://play.grafana.org'
+      setTimeout done, 100
+
+    it 'hubot should respond it cannot configure the host', ->
+      expect(room.messages).to.eql [
+        [ 'alice', 'hubot graf set host http://play.grafana.org' ]
+        [ 'hubot', "Not configured to use multiple configurations"]
+      ]
+
+  context 'ask hubot to configure grafana api_key', ->
+    beforeEach (done) ->
+      room.user.say 'alice', 'hubot graf set api_key AABBCC'
+      setTimeout done, 100
+
+    it 'hubot should respond it cannot configure the api_key', ->
+      expect(room.messages).to.eql [
+        [ 'alice', 'hubot graf set api_key AABBCC' ]
+        [ 'hubot', "Not configured to use multiple configurations"]
+      ]

--- a/test/static-configuration-test.coffee
+++ b/test/static-configuration-test.coffee
@@ -39,7 +39,7 @@ describe 'static configuration', ->
     it 'hubot should respond it cannot configure the host', ->
       expect(room.messages).to.eql [
         [ 'alice', 'hubot graf set host http://play.grafana.org' ]
-        [ 'hubot', "Not configured to use multiple configurations"]
+        [ 'hubot', "Set HUBOT_GRAFANA_PER_ROOM=1 to use multiple configurations."]
       ]
 
   context 'ask hubot to configure grafana api_key', ->
@@ -50,5 +50,5 @@ describe 'static configuration', ->
     it 'hubot should respond it cannot configure the api_key', ->
       expect(room.messages).to.eql [
         [ 'alice', 'hubot graf set api_key AABBCC' ]
-        [ 'hubot', "Not configured to use multiple configurations"]
+        [ 'hubot', "Set HUBOT_GRAFANA_PER_ROOM=1 to use multiple configurations."]
       ]


### PR DESCRIPTION
Following #90 I'm proposing to add:

- a new environment variable to specify the user want to enable per room/channel configuration of the grafana endpoint
- a new command to set the configuration of the grafana host and api_ki and use robot brain to store it. 

The purpose is to be able to use a single instance of the bot within different channel, and each would have a different Grafana instance used for Grafana related queries.

It does not do / support the following:

- check if the user updating the conf is part of an "Admin" list of users allowed to do that
- support multiple Grafana backend for a single room / channel
