### PR TITLE
Improve error handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Note: You won't need to do a version bump in the `package.json` file as we have 
 
 - Test coverage makes the world go round. If you add a feature or fix a bug, be sure to adjust the tests to account for it when practical.
 - Configuration options are preferable to changing something globally. Many folks may depend on the current behavior (e.g. the default time window) and want to leave the default in place.
-- This package is designed to work with all Hubot adapters, so we are not wanting to limit it to only folks who use Slack, HipChat, etc. See [`robot.adapterName`](https://github.com/github/hubot/pull/663) if you want to create an adapter-specific feature.
+- This package is designed to work with all Hubot adapters, so we are not wanting to limit it to only folks who use Slack, IRC, etc. See [`robot.adapterName`](https://github.com/github/hubot/pull/663) if you want to create an adapter-specific feature.
 - If you find yourself copying large blocks of code, consider refactoring it to be a bit more [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself).
 - `robot.logger.debug` and `robot.logger.error` are helpful methods. You can set your `HUBOT_LOG_LEVEL` locally to see the output of these methods as your code is run.
 - If you have something super custom (say, wanting to prefix every command with "hey Siri ..."), it is totally fine to fork this repository and _not_ submit back a Pull Request. You can include your forked version in Hubot by specifying the repository URL in the version field in `package.json`.

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -399,9 +399,6 @@ module.exports = (robot) ->
           ],
           unfurl_links: false
         }
-      # Hipchat
-      when 'hipchat'
-        msg.send "#{title}: #{link} - #{image}"
       # BearyChat
       when 'bearychat'
         robot.emit 'bearychat.attachment', {

--- a/test/grafana-v5-test.coffee
+++ b/test/grafana-v5-test.coffee
@@ -208,3 +208,31 @@ describe 'grafana v5', ->
         [ 'alice', 'hubot graf unpause alert 1' ]
         [ 'hubot', 'alert un-paused']
       ]
+
+  context 'handle an invalid response from the API', ->
+    beforeEach (done) ->
+      nock('http://play.grafana.org')
+        .get('/api/search?type=dash-db')
+        .reply(200, 'I\'m a teapot.')
+      room.user.say 'alice', 'hubot graf list'
+      setTimeout done, 100
+
+    it 'hubot should respond with an error message', ->
+      expect(room.messages).to.eql [
+        [ 'alice', 'hubot graf list' ]
+        [ 'hubot', 'An error ocurred calling the Grafana API on <http://play.grafana.org>. See logs for details.']
+      ]
+
+  context 'handle a server error from the API', ->
+    beforeEach (done) ->
+      nock('http://play.grafana.org')
+        .get('/api/search?type=dash-db')
+        .reply(500)
+      room.user.say 'alice', 'hubot graf list'
+      setTimeout done, 100
+
+    it 'hubot should respond with an error message', ->
+      expect(room.messages).to.eql [
+        [ 'alice', 'hubot graf list' ]
+        [ 'hubot', 'An error ocurred calling the Grafana API on <http://play.grafana.org>. See logs for details.']
+      ]

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,0 @@
---compilers coffee:coffee-script/register
---reporter list
---require coffee-script
---require test/test_helper.coffee
---colors
---full-trace

--- a/test/test_helper.coffee
+++ b/test/test_helper.coffee
@@ -1,2 +1,0 @@
-process.env.NODE_ENV = 'test'
-process.env.HUBOT_DEPLOY_APPS_JSON = require("path").join(__dirname, "test_apps.json")


### PR DESCRIPTION
Prior to this PR, invalid responses from the Grafana API would cause a `SyntaxError` within the `JSON.parse()` method and not offer the user any further feedback. This PR catches those instances with a more descriptive error.

Related: #126 #91 