### PR TITLE
Add TimeZone support (fixes #130)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This follows the standard [GitHub Flow](https://guides.github.com/introduction/f
 
 1. [Open a GitHub Issue](https://github.com/stephenyeargin/hubot-grafana/issues/new) before starting. This is a great way to get feedback from other users on your idea and helps clarify what the upcoming PR will accomplish.
 2. [Fork the repository](https://github.com/stephenyeargin/hubot-grafana/fork) to your account or organization.
-3. Clone the repository locally and run `npm install` to download the necessary dependancies.
+3. Clone the repository locally and run `npm install` to download the necessary dependencies.
 4. Run the test suite with `npm test` in your cloned repository. This is to make sure you've got everything you need to get started.
 5. Use `npm link` in the cloned repository and then run `nmp link hubot-grafana` in your Hubot checkout to connect your cloned version to your local Hubot install. Now you can test changes with your own data!
 6. Commit and push changes back to your forked repository.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ Then add **hubot-grafana** to your `external-scripts.json`:
 
 ### General Settings
 
-| Configuration Variable           | Required | Description                    |
-| -------------------------------- | -------- | ------------------------------ |
-| `HUBOT_GRAFANA_HOST`             | **Yes^**  | Host for your Grafana 2.x install, e.g. `http://play.grafana.org` |
-| `HUBOT_GRAFANA_API_KEY`          | _Yes^^_   | Grafana API key (This can be "Viewer" role.) |
-| `HUBOT_GRAFANA_PER_ROOM`         | No       | Allow per room Grafana Host & API key configuration |
-| `HUBOT_GRAFANA_QUERY_TIME_RANGE` | No       | Default time range for queries (defaults to 6h) |
-| `HUBOT_GRAFANA_DEFAULT_WIDTH`    | No       | Default width for rendered images (defaults to 1000) |
-| `HUBOT_GRAFANA_DEFAULT_HEIGHT`   | No       | Default height for rendered images (defaults to 500) |
+| Configuration Variable            | Required | Description                    |
+| --------------------------------- | -------- | ------------------------------ |
+| `HUBOT_GRAFANA_HOST`              | **Yes^** | Host for your Grafana 2.x install, e.g. `http://play.grafana.org` |
+| `HUBOT_GRAFANA_API_KEY`           | _Yes^^_  | Grafana API key (This can be "Viewer" role.) |
+| `HUBOT_GRAFANA_PER_ROOM`          | No       | Allow per room Grafana Host & API key configuration |
+| `HUBOT_GRAFANA_QUERY_TIME_RANGE`  | No       | Default time range for queries (defaults to 6h) |
+| `HUBOT_GRAFANA_DEFAULT_WIDTH`     | No       | Default width for rendered images (defaults to 1000) |
+| `HUBOT_GRAFANA_DEFAULT_HEIGHT`    | No       | Default height for rendered images (defaults to 500) |
+| `HUBOT_GRAFANA_DEFAULT_TIME_ZONE` | No       | Default time zone for rendered images (defaults to `""`) |
 
 ^ _Not required when `HUBOT_GRAFANA_PER_ROOM` is set to 1._
 

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -11,6 +11,7 @@
 #   - `hubot graf db graphite-carbon-metrics now-12hr` - Get a dashboard with a window of 12 hours ago to now
 #   - `hubot graf db graphite-carbon-metrics now-24hr now-12hr` - Get a dashboard with a window of 24 hours ago to 12 hours ago
 #   - `hubot graf db graphite-carbon-metrics:3 now-8d now-1d` - Get only the third panel of a particular dashboard with a window of 8 days ago to yesterday
+#   - `hubot graf db graphite-carbon-metrics:3 tz=Europe/Amsterdam` - Get only the third panel of a particular dashboard and render in the time zone Europe/Amsterdam
 #
 # Configuration:
 #   HUBOT_GRAFANA_HOST - Host for your Grafana 2.0 install, e.g. 'http://play.grafana.org'
@@ -42,7 +43,7 @@
 #
 # Commands:
 #   hubot graf set `[host|api_key]` <value> - Setup Grafana host or API key
-#   hubot graf db <dashboard slug>[:<panel id>][ <template variables>][ <from clause>][ <to clause>][ <tz clause>] - Show grafana dashboard graphs
+#   hubot graf db <dashboard slug>[:<panel id>][ <template variables>][ <from clause>][ <to clause>] - Show grafana dashboard graphs
 #   hubot graf list <tag> - Lists all dashboards available (optional: <tag>)
 #   hubot graf search <keyword> - Search available dashboards by <keyword>
 #   hubot graf alerts[ <state>] - Show all alerts (optional: <state>)

--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -233,7 +233,7 @@ module.exports = (robot) ->
 
           # Build links for message sending
           title = formatTitleWithTemplate(panel.title, template_map)
-          imageUrl = "#{endpoint.host}/render/#{apiEndpoint}/db/#{slug}/?panelId=#{panel.id}&width=#{imagesize.width}&height=#{imagesize.height}&from=#{timespan.from}&to=#{timespan.to}#{variables}"
+          imageUrl = "#{endpoint.host}/render/#{apiEndpoint}/db/#{slug}/?panelId=#{panel.id}&width=#{query.width}&height=#{query.height}&from=#{timespan.from}&to=#{timespan.to}#{variables}"
           if query.tz
             imageUrl += "&tz=#{encodeURIComponent query.tz}"
           link = "#{endpoint.host}/dashboard/db/#{slug}/?panelId=#{panel.id}&fullscreen&from=#{timespan.from}&to=#{timespan.to}#{variables}"

--- a/test/timezone-test.coffee
+++ b/test/timezone-test.coffee
@@ -1,0 +1,58 @@
+Helper = require('hubot-test-helper')
+chai = require 'chai'
+sinon = require 'sinon'
+chai.use require 'sinon-chai'
+nock = require('nock')
+
+helper = new Helper('./../src/grafana.coffee')
+
+expect = chai.expect
+
+describe 'retrieve graphs by timezone', ->
+  room = null
+
+  beforeEach ->
+    process.env.HUBOT_GRAFANA_HOST = 'http://play.grafana.org'
+    process.env.HUBOT_GRAFANA_DEFAULT_TIME_ZONE = 'America/Chicago'
+    room = helper.createRoom()
+    nock.disableNetConnect()
+
+    @robot =
+      respond: sinon.spy()
+      hear: sinon.spy()
+
+    require('../src/grafana')(@robot)
+
+  afterEach ->
+    room.destroy()
+    nock.cleanAll()
+    delete process.env.HUBOT_GRAFANA_HOST
+    delete process.env.HUBOT_GRAFANA_DEFAULT_TIME_ZONE
+
+  context 'get a dashboard with the default timezone set', ->
+    beforeEach (done) ->
+      nock('http://play.grafana.org')
+        .get('/api/dashboards/db/templating')
+        .replyWithFile(200, __dirname + '/fixtures/v5/dashboard-templating.json')
+      room.user.say 'alice', 'hubot graf db templating:requests server=backend_01 now-6h'
+      setTimeout done, 100
+
+    it 'hubot should respond with default timezone set', ->
+      expect(room.messages).to.eql [
+        [ 'alice', 'hubot graf db templating:requests server=backend_01 now-6h' ]
+        [ 'hubot', 'Requests / s: http://play.grafana.org/render/dashboard-solo/db/templating/?panelId=1&width=1000&height=500&from=now-6h&to=now&var-server=backend_01&tz=America%2FChicago - http://play.grafana.org/dashboard/db/templating/?panelId=1&fullscreen&from=now-6h&to=now&var-server=backend_01']
+      ]
+
+  context 'get a dashboard with the requested timezone set', ->
+    beforeEach (done) ->
+      nock('http://play.grafana.org')
+        .get('/api/dashboards/db/templating')
+        .replyWithFile(200, __dirname + '/fixtures/v5/dashboard-templating.json')
+      room.user.say 'alice', 'hubot graf db templating:requests server=backend_01 now-6h tz=Europe/Amsterdam'
+      setTimeout done, 100
+
+    it 'hubot should respond with requested timezone set', ->
+      expect(room.messages).to.eql [
+        [ 'alice', 'hubot graf db templating:requests server=backend_01 now-6h tz=Europe/Amsterdam' ]
+        [ 'hubot', 'Requests / s: http://play.grafana.org/render/dashboard-solo/db/templating/?panelId=1&width=1000&height=500&from=now-6h&to=now&var-server=backend_01&tz=Europe%2FAmsterdam - http://play.grafana.org/dashboard/db/templating/?panelId=1&fullscreen&from=now-6h&to=now&var-server=backend_01']
+      ]


### PR DESCRIPTION
Adds time zone support:
- Use `HUBOT_GRAFANA_DEFAULT_TIME_ZONE` env variable for a default time zone
- Use `tz=Europe/Amsterdam` for a specific time zone when requesting a dashboard
- If no time zone is specified, nothing is added to the `imageUrl`