### PR TITLE
fix: S3 URL parameters in the wrong order causes image to break

### DIFF
--- a/src/grafana.js
+++ b/src/grafana.js
@@ -571,7 +571,7 @@ module.exports = (robot) => {
 
         s3.send(command)
           .then(() => {
-            return sendRobotResponse(msg, title, `https://${s3_bucket}.${s3_region}.s3.amazonaws.com/${params.Key}`, link);
+            return sendRobotResponse(msg, title, `https://${s3_bucket}.s3.${s3_region}.amazonaws.com/${params.Key}`, link);
           })
           .catch((s3Err) => {
             robot.logger.error(`Upload Error Code: ${s3Err}`);

--- a/test/grafana-rocketchat-test.js
+++ b/test/grafana-rocketchat-test.js
@@ -128,7 +128,7 @@ describe('rocketchat', () => {
               '@hubot graf db 97PlYC7Mk:panel-3',
             ]);
             expect(selfRoom.messages[1][1]).to.match(
-              /logins\: https\:\/\/graf\.us-east-2\.s3\.amazonaws\.com\/grafana\/[0-9a-f]+\.png - https\:\/\/play\.grafana\.org\/d\/97PlYC7Mk\/\?panelId=3&fullscreen&from=now-6h&to=now/i,
+              /logins\: https\:\/\/graf\.s3\.us-east-2\.amazonaws\.com\/grafana\/[0-9a-f]+\.png - https\:\/\/play\.grafana\.org\/d\/97PlYC7Mk\/\?panelId=3&fullscreen&from=now-6h&to=now/i,
             );
             expect(nock.activeMocks()).to.be.empty;
             done();

--- a/test/grafana-s3-test.js
+++ b/test/grafana-s3-test.js
@@ -68,7 +68,7 @@ describe('s3', () => {
             expect(
                 selfRoom.messages[1][1].replace(/\/[a-f0-9]{40}\.png/i, '/abdcdef0123456789.png')
               ).to.eql(
-                'CPU: https://graf.us-standard.s3.amazonaws.com/grafana/abdcdef0123456789.png - https://play.grafana.org/d/AAy9r_bmk/?panelId=3&fullscreen&from=now-6h&to=now&var-server=ww3.example.com'
+                'CPU: https://graf.s3.us-standard.amazonaws.com/grafana/abdcdef0123456789.png - https://play.grafana.org/d/AAy9r_bmk/?panelId=3&fullscreen&from=now-6h&to=now&var-server=ww3.example.com'
               );
             expect(nock.activeMocks()).to.be.empty;
             done();


### PR DESCRIPTION
This fixes the problem mentioned in #154.

Think you were going for Virtual-host-style-access as mentioned in the docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html#virtual-host-style-url-ex

But the region should come _after_ *s3.* (and it came before). I've changed the tests accordingly.