### PR TITLE
chore: implement OWASP recommendation for package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ coverage.json
 # Node versions (nodenv)
 .node-version
 .vscode/settings.json
+
+# npm pack result
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.github
-.husky
-script
-test
-.editorconfig
-.eslintrc.js
-.release-it.json
-CODE_OF_CONDUCT.md

--- a/package.json
+++ b/package.json
@@ -45,5 +45,12 @@
     "test": "mocha \"test/**/*.js\" --reporter spec --no-experiemental-fetch",
     "prepare": "husky install",
     "lint": "eslint src/ test/"
-  }
+  },
+
+  "files": [
+    "src/grafana.js",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "index.js"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "prepare": "husky install",
     "lint": "eslint src/ test/"
   },
-
   "files": [
     "src/grafana.js",
     "CONTRIBUTING.md",


### PR DESCRIPTION
Last week I had a security incident in which I uploaded something to NPM that should not have been uploaded. Because we had both a .gitignore AND an .npmingore file, the .gitignore was actually ignored. When reviewing the OWASP guidelines, I saw the recommendation that it is better to work with an explicit whitelist, instead of a blacklist (https://cheatsheetseries.owasp.org/cheatsheets/NPM_Security_Cheat_Sheet.html#1-avoid-publishing-secrets-to-the-npm-registry).

I've removed the .npmignore and added the files to the `files` property of the package.json. This prevents us from leaking information accidentally. 