### PR TITLE
fix: load rights scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = function(robot, scripts) {
+module.exports = function (robot) {
   const scriptsPath = path.resolve(__dirname, 'src');
   if (fs.existsSync(scriptsPath)) {
-    return (() => {
-      const result = [];
-      for (let script of Array.from(fs.readdirSync(scriptsPath).sort())) {
-        if ((scripts != null) && !Array.from(scripts).includes('*')) {
-          if (Array.from(scripts).includes(script)) { result.push(robot.loadFile(scriptsPath, script)); } else {
-            result.push(undefined);
-          }
-        } else {
-          result.push(robot.loadFile(scriptsPath, script));
-        }
-      }
-      return result;
-    })();
+    let scripts = ['grafana.js'].sort();
+    for (let script of scripts) {
+      robot.loadFile(scriptsPath, script);
+    }
   }
 };


### PR DESCRIPTION
After inspecting the logs, I saw that the loader tries to `require` the following files:

- http.js
- grafana-client.js

These files will never contain something Hubot can work with. I've changed the way the loader works, so only the `grafana.js` file is loaded. When we want to load more files, we can add it to the `index.js`.