### PR TITLE
Add support for from= and to= parameters

### DIFF
--- a/src/grafana.js
+++ b/src/grafana.js
@@ -122,17 +122,28 @@ module.exports = (robot) => {
 
       for (const part of Array.from(remainder.trim().split(' '))) {
         // Check if it's a variable or part of the timespan
+
         if (part.indexOf('=') >= 0) {
           // put query stuff into its own dict
-          if (part.split('=')[0] in query) {
-            query[part.split('=')[0]] = part.split('=')[1];
+          const [partName, partValue] = part.split('=')
+
+          if (partName in query) {
+            query[partName] = partValue;
+            continue;
+          }
+          else if (partName == "from") {
+            timespan.from = partValue;
+            continue;
+          }
+          else if (partName == "to") {
+            timespan.to = partValue;
             continue;
           }
 
           variables = `${variables}&var-${part}`;
           template_params.push({
-            name: part.split('=')[0],
-            value: part.split('=')[1],
+            name: partName,
+            value: partValue,
           });
         } else if (part == 'kiosk') {
           query.kiosk = true;
@@ -420,8 +431,7 @@ module.exports = (robot) => {
     }
 
     msg.send(
-      `Successfully tried to ${msg.match[1]} *${alerts.length}* alerts.\n*Success: ${
-        alerts.length - errored
+      `Successfully tried to ${msg.match[1]} *${alerts.length}* alerts.\n*Success: ${alerts.length - errored
       }*\n*Errored: ${errored}*`
     );
   });

--- a/test/grafana-v8-test.js
+++ b/test/grafana-v8-test.js
@@ -224,6 +224,22 @@ describe('grafana v8', () => {
     });
   });
 
+  describe('ask hubot to return a specific panel with a custom time range', () => {
+    beforeEach(async () => {
+      ctx
+        .nock('https://play.grafana.org')
+        .get('/api/dashboards/uid/97PlYC7Mk')
+        .replyWithFile(200, `${__dirname}/fixtures/v8/dashboard-grafana-play.json`);
+    });
+
+    it('hubot should respond with a resized image specified in request', async () => {
+      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3 from=1705569109372 to=1705572545230');
+      expect(response).to.eql(
+        'client side full page load: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=5&width=1000&height=500&from=1705569109372&to=1705572545230 - https://play.grafana.org/d/97PlYC7Mk/?panelId=5&fullscreen&from=1705569109372&to=1705572545230'
+      );
+    });
+  });
+
   describe('ask hubot for templated dashboard', () => {
     beforeEach(async () => {
       ctx


### PR DESCRIPTION
Normally dashboards are relative from `now`. This PR makes it possible to supply `to=` and `from=` parameters to share dashboards from a certain timestamp.