### PR TITLE
Fix various errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hubot-grafana",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hubot-grafana",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.565.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-grafana",
   "description": "Query Grafana dashboards",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "author": "Stephen Yeargin <stephen@yearg.in>",
   "license": "MIT",
   "keywords": [

--- a/src/service/GrafanaService.js
+++ b/src/service/GrafanaService.js
@@ -230,7 +230,7 @@ class GrafanaService {
     let page = 1;
 
     while (true) {
-      const url = `search?limit=${pageSize}&page=${encodeURIComponent(slug)}`;
+      const url = `search?limit=${pageSize}&page=${encodeURIComponent(page)}`;
 
       try {
         const items = await client.get(url);
@@ -249,6 +249,7 @@ class GrafanaService {
         page++;
       } catch (err) {
         this.logger.error(err, `Error while getting dashboard on URL: ${url}`);
+        return null;
       }
     }
 


### PR DESCRIPTION
This PR fixes some problems:

- Fixes the way we construct the full URL, especially when people end the host with a `/`. The new `expandUrl` helps to create a URL that is acceptable.
- Error handling: in some cases Grafana will return an HTML page, we don't want that as part of our error object.
- When the first API call of `getUidBySlug` errors out, this can cause an infinite loop. We now break on the first problem. Also, paging was broken, so if you have +5000 dashboards, you could not get the right dashboard.