### PR TITLE
Switch to Prettier + eslint:recommended, fix lint-surfaced bugs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,16 +1,36 @@
 module.exports = {
   env: {
-    browser: true,
+    node: true,
     es2021: true,
-    sinon: true,
+    mocha: true,
   },
-  extends: 'airbnb-base',
-  overrides: [
-  ],
+  extends: ['eslint:recommended', 'plugin:import/recommended', 'prettier'],
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
   rules: {
+    // Loose equality bugs are worth catching; `== null` stays allowed as the
+    // idiomatic null-or-undefined check.
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
+    // getUidBySlug's paginated search loop relies on an internal `break`.
+    'no-constant-condition': ['error', { checkLoops: false }],
   },
+  overrides: [
+    {
+      // TestBotContext is imported purely for `@type {TestBotContext}` JSDoc annotations.
+      files: ['test/**/*.js'],
+      rules: {
+        'no-unused-vars': ['error', { varsIgnorePattern: '^TestBotContext$' }],
+      },
+    },
+    {
+      // Responder/Uploader/TypingIndicator are override-point base classes;
+      // their default no-op methods intentionally ignore their arguments.
+      files: ['src/adapters/Responder.js', 'src/adapters/Uploader.js', 'src/adapters/TypingIndicator.js'],
+      rules: {
+        'no-unused-vars': 'off',
+      },
+    },
+  ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,11 @@ module.exports = {
     es2021: true,
     mocha: true,
   },
+  globals: {
+    // Web-platform globals available in Node 18+ that this eslint/globals
+    // version doesn't yet include under the `node` env.
+    Blob: 'readonly',
+  },
   extends: ['eslint:recommended', 'plugin:import/recommended', 'prettier'],
   parserOptions: {
     ecmaVersion: 'latest',

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+npm run lint
 npm test -- --forbid-only --forbid-pending

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "arrowParens": "always"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,13 @@
         "c8": "^12.0.0",
         "chai": "^6.2.2",
         "eslint": "^8.45.0",
-        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.27.5",
         "hubot": "^14.1.0",
         "husky": "^9.0.11",
         "mocha": "^11.0.0",
-        "nock": "^14.0.17"
+        "nock": "^14.0.17",
+        "prettier": "^3.9.6"
       },
       "engines": {
         "node": ">=18"
@@ -1454,11 +1455,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/confusing-browser-globals": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -1823,31 +1819,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-config-airbnb-base": {
-      "version": "15.0.0",
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5",
-        "semver": "^6.3.0"
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
       },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.2"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -3486,19 +3471,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.entries": {
-      "version": "1.1.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.1.6",
       "dev": true,
@@ -3723,6 +3695,22 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/process-warning": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
     "c8": "^12.0.0",
     "chai": "^6.2.2",
     "eslint": "^8.45.0",
-    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.27.5",
     "hubot": "^14.1.0",
     "husky": "^9.0.11",
     "mocha": "^11.0.0",
-    "nock": "^14.0.17"
+    "nock": "^14.0.17",
+    "prettier": "^3.9.6"
   },
   "main": "index.js",
   "scripts": {

--- a/src/Bot.js
+++ b/src/Bot.js
@@ -23,11 +23,11 @@ class Bot {
   /**
    * Creates a new Grafana service based on the provided message.
    * @param {Hubot.Response} context - The context object.
-   * @returns {GrafanaService|null} - The created Grafana service or null if the client is not available.
+   * @returns {GrafanaService|null} - The created Grafana service or null if
+   *   the client is not available.
    */
   createService(context) {
-
-    const robot = context.robot;
+    const { robot } = context;
     let host = process.env.HUBOT_GRAFANA_HOST;
     let apiKey = process.env.HUBOT_GRAFANA_API_KEY;
 
@@ -42,7 +42,7 @@ class Bot {
       return null;
     }
 
-    let client = new GrafanaClient(robot.logger, host, apiKey);
+    const client = new GrafanaClient(robot.logger, host, apiKey);
     return new GrafanaService(client);
   }
 
@@ -50,7 +50,8 @@ class Bot {
    * Sends dashboard charts based on a request string.
    *
    * @param {Hubot.Response} context - The context object.
-   * @param {string} requestString - The request string. This string may contain all the parameters to fetch a dashboard (should not contain the `@hubot graf db` part).
+   * @param {string} requestString - The request string. This string may contain all the parameters
+   *   to fetch a dashboard (should not contain the `@hubot graf db` part).
    * @param {number} maxReturnDashboards - The maximum number of dashboards to return.
    * @returns {Promise<void>} - A promise that resolves when the charts are sent.
    */
@@ -63,11 +64,13 @@ class Bot {
 
     // Check dashboard information
     if (!dashboard) {
-      return this.sendError('An error ocurred. Check your logs for more details.', context);
+      this.sendError('An error ocurred. Check your logs for more details.', context);
+      return;
     }
 
     if (dashboard.message) {
-      return this.sendError(dashboard.message, context);
+      this.sendError(dashboard.message, context);
+      return;
     }
 
     // Defaults
@@ -75,16 +78,19 @@ class Bot {
 
     // Handle empty dashboard
     if (data.rows == null) {
-      return this.sendError('Dashboard empty.', context);
+      this.sendError('Dashboard empty.', context);
+      return;
     }
 
-    maxReturnDashboards = maxReturnDashboards || parseInt(process.env.HUBOT_GRAFANA_MAX_RETURNED_DASHBOARDS, 10) || 25;
-    const charts = await service.getDashboardCharts(req, dashboard, maxReturnDashboards);
+    const envMaxDashboards = process.env.HUBOT_GRAFANA_MAX_RETURNED_DASHBOARDS;
+    const maxDashboards = maxReturnDashboards || parseInt(envMaxDashboards, 10) || 25;
+    const charts = await service.getDashboardCharts(req, dashboard, maxDashboards);
     if (charts == null || charts.length === 0) {
-      return this.sendError('Could not locate desired panel.', context);
+      this.sendError('Could not locate desired panel.', context);
+      return;
     }
 
-    for (let chart of charts) {
+    for (const chart of charts) {
       await this.sendDashboardChart(context, chart);
     }
   }
@@ -111,7 +117,8 @@ class Bot {
     try {
       file = await service.client.download(dashboard.imageUrl);
     } catch (err) {
-      return this.sendError(err, context);
+      this.sendError(err, context);
+      return;
     }
 
     this.logger.debug(`Uploading file: ${file.body.length} bytes, content-type[${file.contentType}]`);

--- a/src/Bot.js
+++ b/src/Bot.js
@@ -83,7 +83,7 @@ class Bot {
     }
 
     const envMaxDashboards = process.env.HUBOT_GRAFANA_MAX_RETURNED_DASHBOARDS;
-    const maxDashboards = maxReturnDashboards || parseInt(envMaxDashboards, 10) || 25;
+    const maxDashboards = parseInt(maxReturnDashboards, 10) || parseInt(envMaxDashboards, 10) || 25;
     const charts = await service.getDashboardCharts(req, dashboard, maxDashboards);
     if (charts == null || charts.length === 0) {
       this.sendError('Could not locate desired panel.', context);

--- a/src/adapters/Adapter.js
+++ b/src/adapters/Adapter.js
@@ -5,6 +5,7 @@ const { SlackResponder } = require('./implementations/SlackResponder');
 const { BearyChatResponder } = require('./implementations/BearyChatResponder');
 const { HipChatResponder } = require('./implementations/HipChatResponder');
 
+// eslint-disable-next-line no-unused-vars -- imported for the @type {Uploader} JSDoc annotation below
 const { Uploader } = require('./Uploader');
 const { S3Uploader } = require('./implementations/S3Uploader');
 const { RocketChatUploader } = require('./implementations/RocketChatUploader');
@@ -60,8 +61,7 @@ class Adapter {
    */
   /** @type {Responder} */
   get responder() {
-
-    if(overrideResponder){
+    if (overrideResponder) {
       return overrideResponder;
     }
 
@@ -93,9 +93,9 @@ class Adapter {
         return new SlackUploader(this.robot, this.robot.logger);
       case 'telegram':
         return new TelegramUploader();
+      default:
+        throw new Error(`Upload not supported for '${this.robot.adapterName}'`);
     }
-
-    throw new Error(`Upload not supported for '${this.robot.adapterName}'`);
   }
 
   /**
@@ -111,15 +111,15 @@ class Adapter {
  * Overrides the responder.
  * @param {Responder} responder The responder to use.
  */
-exports.setResponder = function(responder) {
+exports.setResponder = function setResponder(responder) {
   overrideResponder = responder;
-}
+};
 
 /**
  * Clears the override responder.
  */
-exports.clearResponder = function() {
+exports.clearResponder = function clearResponder() {
   overrideResponder = null;
-}
+};
 
 exports.Adapter = Adapter;

--- a/src/adapters/Responder.js
+++ b/src/adapters/Responder.js
@@ -1,4 +1,5 @@
 'strict';
+
 class Responder {
   /**
    * Sends the response to Hubot.

--- a/src/adapters/Uploader.js
+++ b/src/adapters/Uploader.js
@@ -1,6 +1,6 @@
 'strict';
-class Uploader {
 
+class Uploader {
   /**
    * Uploads the a screenshot of the dashboards.
    *

--- a/src/adapters/implementations/BearyChatResponder.js
+++ b/src/adapters/implementations/BearyChatResponder.js
@@ -1,4 +1,5 @@
 'strict';
+
 const { Responder } = require('../Responder');
 
 class BearyChatResponder extends Responder {
@@ -12,6 +13,7 @@ class BearyChatResponder extends Responder {
     /** @type {Hubot.Robot} */
     this.robot = robot;
   }
+
   /**
    * Sends the response to Hubot.
    * @param {Hubot.Response} res the context.

--- a/src/adapters/implementations/HipChatResponder.js
+++ b/src/adapters/implementations/HipChatResponder.js
@@ -1,5 +1,6 @@
 'strict';
-const { Responder } = require("../Responder");
+
+const { Responder } = require('../Responder');
 
 class HipChatResponder extends Responder {
   /**

--- a/src/adapters/implementations/RocketChatUploader.js
+++ b/src/adapters/implementations/RocketChatUploader.js
@@ -1,4 +1,5 @@
 'strict';
+
 const { Uploader } = require('../Uploader');
 
 class RocketChatUploader extends Uploader {
@@ -24,7 +25,7 @@ class RocketChatUploader extends Uploader {
       !this.rocketchat_url.startsWith('http://') &&
       !this.rocketchat_url.startsWith('https://')
     ) {
-      this.rocketchat_url = `http://${rocketchat_url}`;
+      this.rocketchat_url = `http://${this.rocketchat_url}`;
     }
 
     /** @type {Hubot.Robot} */
@@ -49,7 +50,7 @@ class RocketChatUploader extends Uploader {
     let rocketchatResBodyJson = null;
 
     try {
-      rocketchatResBodyJson = await post(authUrl, authForm);
+      rocketchatResBodyJson = await this.post(authUrl, authForm);
     } catch (err) {
       this.logger.error(err);
       throw new Error('Could not authenticate.');
@@ -73,7 +74,7 @@ class RocketChatUploader extends Uploader {
    *
    * @param {Hubot.Response} res the context.
    * @param {string} title the title of the dashboard.
-   * @param {{ body: Buffer, contentType: string}=>void} file the screenshot.
+   * @param {{ body: Buffer, contentType: string }} file the screenshot.
    * @param {string} grafanaChartLink link to the Grafana chart.
    */
   async upload(res, title, file, grafanaChartLink) {
@@ -81,7 +82,8 @@ class RocketChatUploader extends Uploader {
     try {
       authHeaders = await this.login();
     } catch (ex) {
-      let msg = ex == 'Could not authenticate.' ? "invalid url, user or password/can't access rocketchat api" : ex;
+      const msg =
+        ex.message === 'Could not authenticate.' ? "invalid url, user or password/can't access rocketchat api" : ex;
       res.send(`${title} - [Rocketchat auth Error - ${msg}] - ${grafanaChartLink}`);
       return;
     }
@@ -113,7 +115,7 @@ class RocketChatUploader extends Uploader {
 
     if (!body.success) {
       this.logger.error(`rocketchat service error while posting data:${body.error}`);
-      return res.send(`${title} - [Form Error: can't upload file : ${body.error}] - ${grafanaChartLink}`);
+      res.send(`${title} - [Form Error: can't upload file : ${body.error}] - ${grafanaChartLink}`);
     }
   }
 
@@ -127,7 +129,7 @@ class RocketChatUploader extends Uploader {
   async post(url, formData, headers = null) {
     const response = await fetch(url, {
       method: 'POST',
-      headers: headers,
+      headers,
       body: new FormData(formData),
     });
 

--- a/src/adapters/implementations/RocketChatUploader.js
+++ b/src/adapters/implementations/RocketChatUploader.js
@@ -83,7 +83,9 @@ class RocketChatUploader extends Uploader {
       authHeaders = await this.login();
     } catch (ex) {
       const msg =
-        ex.message === 'Could not authenticate.' ? "invalid url, user or password/can't access rocketchat api" : ex;
+        ex.message === 'Could not authenticate.'
+          ? "invalid url, user or password/can't access rocketchat api"
+          : ex.message;
       res.send(`${title} - [Rocketchat auth Error - ${msg}] - ${grafanaChartLink}`);
       return;
     }
@@ -123,14 +125,24 @@ class RocketChatUploader extends Uploader {
    * Posts the data data to the specified url and returns JSON.
    * @param {string} url - the URL
    * @param {Record<string, unknown>} formData - formatData
-   * @param {Record<string, string>|null} headers - formatData
+   * @param {Record<string, string>} [headers] - request headers
    * @returns {Promise<unknown>} The deserialized JSON response or an error if something went wrong.
    */
-  async post(url, formData, headers = null) {
+  async post(url, formData, headers) {
+    const body = new FormData();
+    for (const [key, value] of Object.entries(formData)) {
+      if (value && typeof value === 'object' && 'value' in value) {
+        const { value: fileValue, options = {} } = value;
+        body.append(key, new Blob([fileValue], { type: options.contentType }), options.filename);
+      } else {
+        body.append(key, value);
+      }
+    }
+
     const response = await fetch(url, {
       method: 'POST',
       headers,
-      body: new FormData(formData),
+      body,
     });
 
     if (!response.ok) {

--- a/src/adapters/implementations/S3Uploader.js
+++ b/src/adapters/implementations/S3Uploader.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 const { Uploader } = require('../Uploader');
+// eslint-disable-next-line no-unused-vars -- imported for the @type {Responder} JSDoc annotation below
 const { Responder } = require('../Responder');
 
 class S3Uploader extends Uploader {
@@ -61,7 +62,12 @@ class S3Uploader extends Uploader {
 
     s3.send(command)
       .then(() => {
-        this.responder.send(res, title, `https://${this.s3_bucket}.s3.${this.s3_region}.amazonaws.com/${params.Key}`, grafanaChartLink);
+        this.responder.send(
+          res,
+          title,
+          `https://${this.s3_bucket}.s3.${this.s3_region}.amazonaws.com/${params.Key}`,
+          grafanaChartLink
+        );
       })
       .catch((s3Err) => {
         this.logger.error(`Upload Error Code: ${s3Err}`);

--- a/src/adapters/implementations/SlackResponder.js
+++ b/src/adapters/implementations/SlackResponder.js
@@ -1,5 +1,6 @@
 'strict';
-const { Responder } = require("../Responder");
+
+const { Responder } = require('../Responder');
 
 class SlackResponder extends Responder {
   constructor() {
@@ -17,8 +18,7 @@ class SlackResponder extends Responder {
    * @param {string} dashboardLink the title of the link
    */
   send(res, title, imageUrl, dashboardLink) {
-
-    let thread_ts = null
+    let thread_ts = null;
     if (this.use_threads) {
       thread_ts = res.message.rawMessage.ts;
     }
@@ -33,7 +33,7 @@ class SlackResponder extends Responder {
         },
       ],
       unfurl_links: false,
-      thread_ts: thread_ts
+      thread_ts,
     });
   }
 }

--- a/src/adapters/implementations/SlackUploader.js
+++ b/src/adapters/implementations/SlackUploader.js
@@ -19,7 +19,6 @@ class SlackUploader extends Uploader {
 
     /** @type {Hubot.Log} */
     this.logger = logger;
-
   }
 
   /**
@@ -35,12 +34,12 @@ class SlackUploader extends Uploader {
     const channel = res.envelope.room;
 
     try {
-      let options = {
-        filename: title + '.png',
+      const options = {
+        filename: `${title}.png`,
         file: Buffer.from(file.body),
         title: 'dashboard',
         initial_comment: `${title}: ${grafanaChartLink}`,
-        thread_ts: thread_ts,
+        thread_ts,
         channels: channel,
       };
 

--- a/src/adapters/implementations/TelegramUploader.js
+++ b/src/adapters/implementations/TelegramUploader.js
@@ -1,4 +1,5 @@
 'strict';
+
 const { Uploader } = require('../Uploader');
 
 class TelegramUploader extends Uploader {

--- a/src/grafana-client.js
+++ b/src/grafana-client.js
@@ -1,16 +1,16 @@
 'strict';
+
 const { URL, URLSearchParams } = require('url');
 
 /// <reference path="../types.d.ts"/>
 
-  /**
-   * If the given url does not have a host, it will add it to the
-   * url and return it.
-   * @param {string} url the url
-   * @returns {string} the expanded URL.
-   */
+/**
+ * If the given url does not have a host, it will add it to the
+ * url and return it.
+ * @param {string} url the url
+ * @returns {string} the expanded URL.
+ */
 function expandUrl(url, host) {
-
   if (url.startsWith('http://') || url.startsWith('https://')) {
     return url;
   }
@@ -28,6 +28,33 @@ function expandUrl(url, host) {
   apiUrl += url;
 
   return apiUrl;
+}
+
+/**
+ * Create headers for the Grafana request.
+ * @param {string | null} contentType Indicates if the HTTP client should post.
+ * @param {string | false} encoding Indicates if an encoding should be set.
+ * @param {string | null} api_key The API key.
+ * @returns {Record<string, string|null>}
+ */
+function grafanaHeaders(contentType, encoding, api_key) {
+  const headers = { Accept: 'application/json' };
+
+  if (contentType) {
+    headers['Content-Type'] = contentType;
+  }
+
+  // download needs a null encoding
+  // TODO: are we sure?
+  if (encoding !== false) {
+    headers.encoding = encoding;
+  }
+
+  if (api_key) {
+    headers.Authorization = `Bearer ${api_key}`;
+  }
+
+  return headers;
 }
 
 class GrafanaClient {
@@ -111,19 +138,19 @@ class GrafanaClient {
     if (response.headers.has('content-type')) {
       contentType = response.headers.get('content-type');
       if (contentType.includes(';')) {
-        contentType = contentType.split(';')[0];
+        [contentType] = contentType.split(';');
       }
     }
 
-    if (contentType == 'application/json') {
+    if (contentType === 'application/json') {
       const json = await response.json();
       const error = new Error(json.message || 'Error while fetching data from Grafana.');
       error.data = json;
       throw error;
     }
 
-    let error = new Error('Error while fetching data from Grafana.');
-    if (contentType != 'text/html') {
+    const error = new Error('Error while fetching data from Grafana.');
+    if (contentType !== 'text/html') {
       error.data = await response.text();
     }
 
@@ -136,7 +163,7 @@ class GrafanaClient {
    * @returns {Promise<DownloadedFile>}
    */
   async download(url) {
-    let response = await fetch(url, {
+    const response = await fetch(url, {
       method: 'GET',
       headers: grafanaHeaders(null, null, this.apiKey),
     });
@@ -148,7 +175,7 @@ class GrafanaClient {
 
     return {
       body: Buffer.from(body),
-      contentType: contentType,
+      contentType,
     };
   }
 
@@ -207,40 +234,13 @@ class GrafanaClient {
       url.searchParams.set('tz', query.tz);
     }
 
-    //TODO: currently not tested
+    // TODO: currently not tested
     if (query.orgId) {
       url.searchParams.set('orgId', query.orgId);
     }
 
     return url.toString().replace('kiosk=&', 'kiosk&').replace('autofitpanels=&', 'autofitpanels&');
   }
-}
-
-/**
- * Create headers for the Grafana request.
- * @param {string | null} contentType Indicates if the HTTP client should post.
- * @param {string | false} encoding Indicates if an encoding should be set.
- * @param {string | null} api_key The API key.
- * @returns {Record<string, string|null>}
- */
-function grafanaHeaders(contentType, encoding, api_key) {
-  const headers = { Accept: 'application/json' };
-
-  if (contentType) {
-    headers['Content-Type'] = contentType;
-  }
-
-  // download needs a null encoding
-  // TODO: are we sure?
-  if (encoding !== false) {
-    headers['encoding'] = encoding;
-  }
-
-  if (api_key) {
-    headers.Authorization = `Bearer ${api_key}`;
-  }
-
-  return headers;
 }
 
 exports.GrafanaClient = GrafanaClient;

--- a/src/grafana.js
+++ b/src/grafana.js
@@ -58,7 +58,7 @@ const { Bot } = require('./Bot');
 module.exports = (robot) => {
   // Various configuration options stored in environment variables
   const grafanaPerRoom = process.env.HUBOT_GRAFANA_PER_ROOM;
-  const maxReturnDashboards = process.env.HUBOT_GRAFANA_MAX_RETURNED_DASHBOARDS || 25;
+  const maxReturnDashboards = parseInt(process.env.HUBOT_GRAFANA_MAX_RETURNED_DASHBOARDS, 10) || 25;
   const bot = new Bot(robot);
 
   /**

--- a/src/grafana.js
+++ b/src/grafana.js
@@ -61,6 +61,37 @@ module.exports = (robot) => {
   const maxReturnDashboards = process.env.HUBOT_GRAFANA_MAX_RETURNED_DASHBOARDS || 25;
   const bot = new Bot(robot);
 
+  /**
+   * Sends the list of dashboards.
+   * @param {Array<GrafanaSearchResponse>} dashboards the list of dashboards
+   * @param {string} title the title that is printed before the result
+   * @param {Hubot.Response} res the context.
+   */
+  async function sendDashboardList(dashboards, title, res) {
+    robot.logger.debug(dashboards);
+    if (!(dashboards.length > 0)) {
+      return;
+    }
+
+    let remaining = 0;
+    let shownDashboards = dashboards;
+    if (dashboards.length > maxReturnDashboards) {
+      remaining = dashboards.length - maxReturnDashboards;
+      shownDashboards = dashboards.slice(0, maxReturnDashboards - 1);
+    }
+
+    const list = [];
+    for (const dashboard of Array.from(shownDashboards)) {
+      list.push(`- ${dashboard.uid}: ${dashboard.title}`);
+    }
+
+    if (remaining) {
+      list.push(` (and ${remaining} more)`);
+    }
+
+    res.send(title + list.join('\n'));
+  }
+
   // Set Grafana host/api_key
   robot.respond(/(?:grafana|graph|graf) set (host|api_key) (.+)/i, (msg) => {
     if (grafanaPerRoom !== '1') {
@@ -73,10 +104,10 @@ module.exports = (robot) => {
   });
 
   // Get a specific dashboard with options
-  robot.respond(/(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-\:_]+)(.*)?/i, async (context) => {
+  robot.respond(/(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\-:_]+)(.*)?/i, async (context) => {
     let str = context.match[1];
     if (context.match[2]) {
-      str += ' ' + context.match[2];
+      str += ` ${context.match[2]}`;
     }
 
     await bot.sendDashboardChartFromString(context, str, maxReturnDashboards);
@@ -144,7 +175,7 @@ module.exports = (robot) => {
       if (alert.executionError) {
         line += `\n  execution error: ${alert.executionError}`;
       }
-      text += line + `\n`;
+      text += `${line}\n`;
     }
     msg.send(text.trim());
   });
@@ -172,40 +203,9 @@ module.exports = (robot) => {
     const command = msg.match[1];
     const paused = command === 'pause';
     const result = await service.pauseAllAlerts(paused);
-    if (result.total == 0) return;
+    if (result.total === 0) return;
     msg.send(
       `Successfully tried to ${command} *${result.total}* alerts.\n*Success: ${result.success}*\n*Errored: ${result.errored}*`
     );
   });
-
-  /**
-   * Sends the list of dashboards.
-   * @param {Array<GrafanaSearchResponse>} dashboards the list of dashboards
-   * @param {string} title the title that is printed before the result
-   * @param {Hubot.Response} res the context.
-   */
-  async function sendDashboardList(dashboards, title, res) {
-    let remaining;
-    robot.logger.debug(dashboards);
-    if (!(dashboards.length > 0)) {
-      return;
-    }
-
-    remaining = 0;
-    if (dashboards.length > maxReturnDashboards) {
-      remaining = dashboards.length - maxReturnDashboards;
-      dashboards = dashboards.slice(0, maxReturnDashboards - 1);
-    }
-
-    const list = [];
-    for (const dashboard of Array.from(dashboards)) {
-      list.push(`- ${dashboard.uid}: ${dashboard.title}`);
-    }
-
-    if (remaining) {
-      list.push(` (and ${remaining} more)`);
-    }
-
-    res.send(title + list.join('\n'));
-  }
 };

--- a/src/service/GrafanaService.js
+++ b/src/service/GrafanaService.js
@@ -1,7 +1,25 @@
 /// <reference path="../../types.d.ts"/>
 
 const { GrafanaDashboardRequest } = require('./query/GrafanaDashboardRequest');
+// eslint-disable-next-line no-unused-vars -- used only in the @type {GrafanaClient} JSDoc below
 const { GrafanaClient } = require('../grafana-client');
+
+/**
+ * Formats the title with the provided template map.
+ *
+ * @param {string} title - The title to be formatted.
+ * @param {Record<string, string>} templateMap - The map containing the template values.
+ * @returns {string} - The formatted title.
+ */
+function formatTitleWithTemplate(title, templateMap) {
+  const safeTitle = title || '';
+  return safeTitle.replace(/\$\w+/g, (match) => {
+    if (templateMap[match]) {
+      return templateMap[match];
+    }
+    return match;
+  });
+}
 
 class GrafanaService {
   /**
@@ -24,11 +42,13 @@ class GrafanaService {
   }
 
   /**
-   * Processes the given string and returns an array of screenshot URLs for the requested dashboards.
+   * Processes the given string and returns an array of screenshot URLs for the requested
+   * dashboards.
    *
    * @param {string} str - The string to be processed.
    * @param {number} maxReturnDashboards - The maximum number of dashboard screenshots to return.
-   * @returns {Promise<Array<DashboardChart>|null>} An array of DashboardResponse objects containing the screenshot URLs.
+   * @returns {Promise<Array<DashboardChart>|null>} An array of DashboardResponse objects
+   *   containing the screenshot URLs.
    */
   async process(str, maxReturnDashboards) {
     const request = this.parseToGrafanaDashboardRequest(str);
@@ -48,21 +68,22 @@ class GrafanaService {
   /**
    * Parses a string into a GrafanaDashboardRequest object.
    * @param {string} str - The string to parse.
-   * @returns {GrafanaDashboardResponse.Response|null} - The parsed GrafanaDashboardRequest object, or null if the string cannot be parsed.
+   * @returns {GrafanaDashboardResponse.Response|null} - The parsed GrafanaDashboardRequest
+   *   object, or null if the string cannot be parsed.
    */
   parseToGrafanaDashboardRequest(str) {
-    const match = str.match(/([A-Za-z0-9\-\:_]+)(.*)/);
+    const match = str.match(/([A-Za-z0-9-:_]+)(.*)/);
     if (!match) return null;
 
     const request = new GrafanaDashboardRequest();
-    request.uid = match[1];
+    [, request.uid] = match;
 
     // Parse out a specific panel
-    if (/\:/.test(request.uid)) {
+    if (/:/.test(request.uid)) {
       let parts = request.uid.split(':');
-      request.uid = parts[0];
+      [request.uid] = parts;
       request.visualPanelId = parseInt(parts[1], 10);
-      if (isNaN(request.visualPanelId)) {
+      if (Number.isNaN(request.visualPanelId)) {
         request.visualPanelId = false;
         request.pname = parts[1].toLowerCase();
       }
@@ -90,10 +111,10 @@ class GrafanaService {
           if (partName in request.query) {
             request.query[partName] = partValue;
             continue;
-          } else if (partName == 'from') {
+          } else if (partName === 'from') {
             request.timespan.from = partValue;
             continue;
-          } else if (partName == 'to') {
+          } else if (partName === 'to') {
             request.timespan.to = partValue;
             continue;
           }
@@ -103,11 +124,10 @@ class GrafanaService {
             name: partName,
             value: partValue,
           });
-        } else if (part == 'kiosk') {
+        } else if (part === 'kiosk') {
           request.query.kiosk = true;
-        }
-        // Only add to the timespan if we haven't already filled out from and to
-        else if (timeFields.length > 0) {
+        } else if (timeFields.length > 0) {
+          // Only add to the timespan if we haven't already filled out from and to
           request.timespan[timeFields.shift()] = part.trim();
         }
       }
@@ -136,7 +156,7 @@ class GrafanaService {
   async getDashboardCharts(req, dashboardResponse, maxReturnDashboards) {
     if (!dashboardResponse || dashboardResponse.message) return null;
 
-    let dashboard = dashboardResponse.dashboard;
+    const { dashboard } = dashboardResponse;
 
     if (req.query.kiosk) {
       req.query.apiEndpoint = 'd';
@@ -148,25 +168,27 @@ class GrafanaService {
         req.timespan,
         req.variables
       );
-      const title = dashboard.title;
+      const { title } = dashboard;
 
       const response = { imageUrl, grafanaChartLink, title };
       return [response];
     }
 
     // Support for templated dashboards
-    let templateMap = {};
+    const templateMap = {};
     this.logger.debug(dashboard.templating.list);
     if (dashboard.templating.list) {
       for (const template of Array.from(dashboard.templating.list)) {
         this.logger.debug(template);
 
-        const _param = req.template_params.find((param) => param.name === template.name);
-        templateMap[`$${template.name}`] = _param
-          ? _param.value
-          : template.current
-          ? template.current.text
-          : `$${template.name}`;
+        const matchedParam = req.template_params.find((param) => param.name === template.name);
+        if (matchedParam) {
+          templateMap[`$${template.name}`] = matchedParam.value;
+        } else if (template.current) {
+          templateMap[`$${template.name}`] = template.current.text;
+        } else {
+          templateMap[`$${template.name}`] = `$${template.name}`;
+        }
       }
     }
 
@@ -213,7 +235,7 @@ class GrafanaService {
         responses.push({ imageUrl, grafanaChartLink, title });
 
         // Skip if we have already returned max count of dashboards
-        if (responses.length == maxReturnDashboards) {
+        if (responses.length === maxReturnDashboards) {
           break;
         }
       }
@@ -229,7 +251,7 @@ class GrafanaService {
    * @returns {Promise<string|null>} The UID of the dashboard, or undefined if not found.
    */
   async getUidBySlug(slug) {
-    let client = this.client;
+    const { client } = this;
 
     const pageSize = 5000;
     let page = 1;
@@ -244,14 +266,14 @@ class GrafanaService {
             uid: i.uid,
             slug: i.url.replace(`/d/${i.uid}/`, ''),
           }))
-          .find((x) => x.slug == slug);
+          .find((x) => x.slug === slug);
 
         if (dashboard && dashboard.uid) {
           return dashboard.uid;
         }
 
-        if (items.length != pageSize) break;
-        page++;
+        if (items.length !== pageSize) break;
+        page += 1;
       } catch (err) {
         this.logger.error(err, `Error while getting dashboard on URL: ${url}`);
         return null;
@@ -286,7 +308,7 @@ class GrafanaService {
 
     // check if we can improve the error message
     if (dashboard && dashboard.message === 'Dashboard not found') {
-      let realUid = await this.getUidBySlug(uid);
+      const realUid = await this.getUidBySlug(uid);
       if (realUid) {
         dashboard.message = `Try your query again with \`${realUid}\` instead of \`${uid}\``;
       }
@@ -386,7 +408,7 @@ class GrafanaService {
     };
 
     const alerts = await this.client.get('alerts');
-    if (alerts == null || alerts.length == 0) {
+    if (alerts == null || alerts.length === 0) {
       return result;
     }
 
@@ -396,32 +418,15 @@ class GrafanaService {
       const url = `alerts/${alert.id}/pause`;
       try {
         await this.client.post(url, { paused });
-        result.success++;
+        result.success += 1;
       } catch (err) {
         this.logger.error(err, `Error for URL: ${url}`);
-        result.errored++;
+        result.errored += 1;
       }
     }
 
     return result;
   }
-}
-
-/**
- * Formats the title with the provided template map.
- *
- * @param {string} title - The title to be formatted.
- * @param {Record<string, string>} templateMap - The map containing the template values.
- * @returns {string} - The formatted title.
- */
-function formatTitleWithTemplate(title, templateMap) {
-  title = title || '';
-  return title.replace(/\$\w+/g, (match) => {
-    if (templateMap[match]) {
-      return templateMap[match];
-    }
-    return match;
-  });
 }
 
 exports.GrafanaService = GrafanaService;

--- a/test/adapters-test.js
+++ b/test/adapters-test.js
@@ -1,6 +1,6 @@
+const { expect } = require('chai');
 const { Adapter } = require('../src/adapters/Adapter');
 const { Uploader } = require('../src/adapters/Uploader');
-const { expect } = require('chai');
 const { SlackUploader } = require('../src/adapters/implementations/SlackUploader');
 const { createTestBot, TestBotContext } = require('./common/TestBot');
 const { SlackResponder } = require('../src/adapters/implementations/SlackResponder');
@@ -12,9 +12,9 @@ const { Responder } = require('../src/adapters/Responder');
 const { RocketChatUploader } = require('../src/adapters/implementations/RocketChatUploader');
 
 describe('adapter', () => {
-  it('Uploader class cannot upload', function () {
-    let uploader = new Uploader();
-    expect(function () {
+  it('Uploader class cannot upload', () => {
+    const uploader = new Uploader();
+    expect(() => {
       uploader.upload();
     }).to.throw('Not supported');
   });
@@ -27,7 +27,7 @@ describe('adapter', () => {
       ctx = await createTestBot();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_S3_BUCKET;
       ctx?.shutdown();
     });
@@ -103,7 +103,7 @@ describe('adapter', () => {
     it('should not support upload for unknown adapter', () => {
       ctx.robot.adapterName = 'my-amazing-fancy-super-unknown-thingy';
       const adapter = new Adapter(ctx.robot);
-      expect(function () {
+      expect(() => {
         adapter.uploader;
       }).to.throw("Upload not supported for 'my-amazing-fancy-super-unknown-thingy'");
       expect(adapter.site).to.eql('');
@@ -128,7 +128,7 @@ describe('adapter', () => {
       ctx = await createTestBot();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       ctx?.shutdown();
     });
 

--- a/test/adapters/rocketchat.js
+++ b/test/adapters/rocketchat.js
@@ -1,3 +1,3 @@
 // Description
 //   Mock Rocket.Chat adapter
-module.exports = (robot) => robot.adapterName = 'rocketchat';
+module.exports = (robot) => (robot.adapterName = 'rocketchat');

--- a/test/adapters/slack.js
+++ b/test/adapters/slack.js
@@ -1,3 +1,3 @@
 // Description
 //   Mock Slack adapter
-module.exports = (robot) => robot.adapterName = 'slack';
+module.exports = (robot) => (robot.adapterName = 'slack');

--- a/test/common/MockAdapter.js
+++ b/test/common/MockAdapter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { Adapter } = require('hubot');
 
 class MockAdapter extends Adapter {
@@ -28,4 +26,4 @@ class MockAdapter extends Adapter {
   }
 }
 
-module.exports = { use: robot => new MockAdapter(robot) };
+module.exports = { use: (robot) => new MockAdapter(robot) };

--- a/test/common/TestBot.js
+++ b/test/common/TestBot.js
@@ -1,6 +1,6 @@
 const { Robot, TextMessage } = require('hubot');
-const MockAdapter = require('./MockAdapter');
 const nock = require('nock');
+const MockAdapter = require('./MockAdapter');
 const grafanaScript = require('../../src/grafana');
 const { Bot } = require('../../src/Bot');
 
@@ -11,12 +11,13 @@ const { Bot } = require('../../src/Bot');
  * @property {string?} name - The name of the bot.
  * @property {string?} alias - The alias of the bot.
  * @property {string?} adapterName - The name of the adapter.
- * 
+ *
  * @typedef {Promise<unknown[]> & { set<unknown[]>(...value:unknown[]):void }} AwaitableValue
  */
 
 class TestBotContext {
   replies = [];
+
   sends = [];
 
   /**
@@ -26,7 +27,6 @@ class TestBotContext {
    * @param {Hubot.User} user - The user.
    */
   constructor(robot, user) {
-
     /** @type {Hubot.Robot} */
     this.robot = robot;
 
@@ -56,7 +56,7 @@ class TestBotContext {
    */
   async sendAndWaitForResponse(message, responseType = 'send') {
     const responsePromise = new Promise((done) => {
-      this.robot.adapter.once(responseType, function (_, strings) {
+      this.robot.adapter.once(responseType, (_, strings) => {
         done(strings[0]);
       });
     });
@@ -71,7 +71,7 @@ class TestBotContext {
    */
   async send(message) {
     const id = (Math.random() + 1).toString(36).substring(7);
-    const textMessage = new TextMessage(this.user, "" + message, id);
+    const textMessage = new TextMessage(this.user, `${message}`, id);
 
     if (message.rawMessage) {
       textMessage.rawMessage = message.rawMessage;

--- a/test/grafana-rocketchat-test.js
+++ b/test/grafana-rocketchat-test.js
@@ -42,7 +42,7 @@ describe('rocketchat', () => {
   });
 
   describe('rocketchat upload', () => {
-    beforeEach(function () {
+    beforeEach(() => {
       ctx
         .nock('http://chat.example.com')
         .post('/api/v1/login')
@@ -55,7 +55,7 @@ describe('rocketchat', () => {
     });
 
     it('should respond with an uploaded graph', async () => {
-      let response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
+      const response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
       expect(response).to.eql(
         'logins: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=3&width=1000&height=500&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
       );

--- a/test/grafana-rocketchat-test.js
+++ b/test/grafana-rocketchat-test.js
@@ -2,78 +2,137 @@ const { expect } = require('chai');
 const { createTestBot, TestBotContext } = require('./common/TestBot');
 
 describe('rocketchat', () => {
-  /** @type {TestBotContext} */
-  let ctx;
-
-  beforeEach(async () => {
-    process.env.ROCKETCHAT_URL = 'http://chat.example.com';
-    process.env.ROCKETCHAT_USER = 'user1';
-    process.env.ROCKETCHAT_PASSWORD = 'sekret';
-
-    ctx = await createTestBot();
-
-    ctx
-      .nock('https://play.grafana.org')
-      .get('/api/dashboards/uid/97PlYC7Mk')
-      .replyWithFile(200, `${__dirname}/fixtures/v8/dashboard-grafana-play.json`);
-
-    ctx
-      .nock('https://play.grafana.org')
-      .defaultReplyHeaders({
-        'Content-Type': 'image/png',
-      })
-      .get('/render/d-solo/97PlYC7Mk/')
-      .query({
-        panelId: 3,
-        width: 1000,
-        height: 500,
-        from: 'now-6h',
-        to: 'now',
-      })
-      .replyWithFile(200, `${__dirname}/fixtures/v8/dashboard-grafana-play.png`);
-  });
-
-  afterEach(() => {
-    delete process.env.ROCKETCHAT_URL;
-    delete process.env.ROCKETCHAT_USER;
-    delete process.env.ROCKETCHAT_PASSWORD;
-
-    ctx?.shutdown();
-  });
-
   describe('rocketchat upload', () => {
-    beforeEach(() => {
+    /** @type {TestBotContext} */
+    let ctx;
+
+    beforeEach(async () => {
+      process.env.ROCKETCHAT_URL = 'http://chat.example.com';
+      process.env.ROCKETCHAT_USER = 'user1';
+      process.env.ROCKETCHAT_PASSWORD = 'sekret';
+
+      ctx = await createTestBot({
+        adapterName: 'hubot-rocketchat',
+      });
+
+      ctx
+        .nock('https://play.grafana.org')
+        .get('/api/dashboards/uid/97PlYC7Mk')
+        .replyWithFile(200, `${__dirname}/fixtures/v8/dashboard-grafana-play.json`);
+
+      ctx
+        .nock('https://play.grafana.org')
+        .defaultReplyHeaders({
+          'Content-Type': 'image/png',
+        })
+        .get('/render/d-solo/97PlYC7Mk/')
+        .query({
+          panelId: 3,
+          width: 1000,
+          height: 500,
+          from: 'now-6h',
+          to: 'now',
+        })
+        .replyWithFile(200, `${__dirname}/fixtures/v8/dashboard-grafana-play.png`);
+    });
+
+    afterEach(() => {
+      delete process.env.ROCKETCHAT_URL;
+      delete process.env.ROCKETCHAT_USER;
+      delete process.env.ROCKETCHAT_PASSWORD;
+
+      ctx?.shutdown();
+    });
+
+    it('uploads the rendered dashboard to RocketChat', async () => {
       ctx
         .nock('http://chat.example.com')
         .post('/api/v1/login')
         .replyWithFile(200, `${__dirname}/fixtures/rocketchat/login.json`);
 
+      const uploadRequest = ctx.createAwaitableValue();
       ctx
         .nock('http://chat.example.com')
         .post('/api/v1/rooms.upload/undefined')
-        .replyWithFile(200, `${__dirname}/fixtures/rocketchat/rooms.upload.json`);
+        .reply(function reply(uri, requestBody) {
+          uploadRequest.set(requestBody, this.req.headers);
+          return [200, { success: true }];
+        });
+
+      await ctx.send('@hubot graf db 97PlYC7Mk:panel-3');
+      const [rawRequestBody] = await uploadRequest;
+      const requestBody = Buffer.from(rawRequestBody, 'hex').toString('utf8');
+
+      // Verify a real multipart body was sent (this is what new FormData(formData)
+      // could never actually produce -- it threw before a request was ever made).
+      expect(requestBody).to.include('name="msg"');
+      expect(requestBody).to.include(
+        'logins: https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
+      );
+      expect(requestBody).to.include('name="file"');
+      expect(requestBody).to.include('filename="logins');
     });
 
-    it('should respond with an uploaded graph', async () => {
+    it('reports an authentication failure without crashing', async () => {
+      ctx
+        .nock('http://chat.example.com')
+        .post('/api/v1/login')
+        .reply(200, { status: 'error', message: 'Bad credentials' });
+
       const response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
       expect(response).to.eql(
-        'logins: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=3&width=1000&height=500&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
+        'logins - [Rocketchat auth Error - Bad credentials] - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
       );
     });
   });
 
   describe('rocketchat and s3', () => {
-    beforeEach(() => {
+    /** @type {TestBotContext} */
+    let ctx;
+
+    beforeEach(async () => {
+      process.env.ROCKETCHAT_URL = 'http://chat.example.com';
+      process.env.ROCKETCHAT_USER = 'user1';
+      process.env.ROCKETCHAT_PASSWORD = 'sekret';
       process.env.HUBOT_GRAFANA_S3_BUCKET = 'graf';
+
+      ctx = await createTestBot({
+        adapterName: 'hubot-rocketchat',
+      });
+
+      ctx
+        .nock('https://play.grafana.org')
+        .get('/api/dashboards/uid/97PlYC7Mk')
+        .replyWithFile(200, `${__dirname}/fixtures/v8/dashboard-grafana-play.json`);
+
+      ctx
+        .nock('https://play.grafana.org')
+        .defaultReplyHeaders({
+          'Content-Type': 'image/png',
+        })
+        .get('/render/d-solo/97PlYC7Mk/')
+        .query({
+          panelId: 3,
+          width: 1000,
+          height: 500,
+          from: 'now-6h',
+          to: 'now',
+        })
+        .replyWithFile(200, `${__dirname}/fixtures/v8/dashboard-grafana-play.png`);
     });
 
     afterEach(() => {
+      delete process.env.ROCKETCHAT_URL;
+      delete process.env.ROCKETCHAT_USER;
+      delete process.env.ROCKETCHAT_PASSWORD;
       delete process.env.HUBOT_GRAFANA_S3_BUCKET;
+
+      ctx?.shutdown();
     });
 
     it('should respond with an uploaded graph', async () => {
       ctx
-        .nock('https://graf.s3.us-east-2.amazonaws.com')
+        .nock('https://graf.s3.us-standard.amazonaws.com')
         .filteringPath(/[a-z0-9]+\.png/g, 'abdcdef0123456789.png')
         .put('/grafana/abdcdef0123456789.png')
         .query({ 'x-id': 'PutObject' })
@@ -82,7 +141,7 @@ describe('rocketchat', () => {
       let response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
       response = response.replace(/\/[a-f0-9]{40}\.png/i, '/abdcdef0123456789.png');
       expect(response).to.eql(
-        'logins: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=3&width=1000&height=500&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
+        'logins: https://graf.s3.us-standard.amazonaws.com/grafana/abdcdef0123456789.png - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
       );
     });
   });

--- a/test/grafana-s3-test.js
+++ b/test/grafana-s3-test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const { createTestBot, TestBotContext } = require('./common/TestBot');
 
 describe('s3', () => {
-  describe('no region provided', function () {
+  describe('no region provided', () => {
     /** @type {TestBotContext} */
     let ctx;
 
@@ -41,7 +41,7 @@ describe('s3', () => {
         .reply(200);
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_S3_BUCKET;
       delete process.env.HUBOT_GRAFANA_S3_REGION;
       delete process.env.AWS_REGION;
@@ -52,14 +52,14 @@ describe('s3', () => {
       let response = await ctx.sendAndWaitForResponse('@hubot graf db AAy9r_bmk:cpu server=ww3.example.com now-6h');
       response = response.replace(/\/[a-f0-9]{40}\.png/i, '/abdcdef0123456789.png');
 
-      let panelRegex = /panelId=(\d+)/;
+      const panelRegex = /panelId=(\d+)/;
       expect(response).to.match(panelRegex);
 
-      let panelId = response.match(panelRegex)[1];
+      const panelId = response.match(panelRegex)[1];
       expect(response).to.eql(
-        'CPU: https://graf.s3.us-standard.amazonaws.com/grafana/abdcdef0123456789.png - https://play.grafana.org/d/AAy9r_bmk/?panelId=' +
-          panelId +
-          '&fullscreen&from=now-6h&to=now&var-server=ww3.example.com'
+        `CPU: https://graf.s3.us-standard.amazonaws.com/grafana/abdcdef0123456789.png - https://play.grafana.org/d/AAy9r_bmk/?panelId=${
+          panelId
+        }&fullscreen&from=now-6h&to=now&var-server=ww3.example.com`
       );
     });
   });

--- a/test/grafana-service-test.js
+++ b/test/grafana-service-test.js
@@ -34,7 +34,7 @@ describe('grafana service', () => {
     );
   });
 
-  afterEach(function () {
+  afterEach(() => {
     ctx?.shutdown();
   });
 
@@ -64,10 +64,7 @@ describe('grafana service', () => {
 
   it('should resolve UID by slug', async () => {
     const service = ctx.bot.createService({ robot: ctx.robot });
-    const result = await service.getUidBySlug("the-four-golden-signals");
+    const result = await service.getUidBySlug('the-four-golden-signals');
     expect(result).to.eql('000000109');
   });
-
-
-  
 });

--- a/test/grafana-slack-test.js
+++ b/test/grafana-slack-test.js
@@ -15,8 +15,9 @@ describe('slack', () => {
        * @param {string} image the URL of the image
        * @param {string} link the title of the link
        */
+      // eslint-disable-next-line no-unused-vars -- overriding Responder.send's signature
       send(res, title, image, link) {
-        res.send('Hiding dashboard: ' + title);
+        res.send(`Hiding dashboard: ${title}`);
       }
     }
 
@@ -31,14 +32,14 @@ describe('slack', () => {
       });
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_S3_BUCKET;
       clearResponder();
       ctx?.shutdown();
     });
 
     it('should respond with an uploaded graph', async () => {
-      let response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
+      const response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
       expect(response).to.eql('Hiding dashboard: logins');
     });
   });
@@ -54,13 +55,13 @@ describe('slack', () => {
       });
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_S3_BUCKET;
       ctx?.shutdown();
     });
 
     it('should respond with an uploaded graph', async () => {
-      let response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
+      const response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
 
       expect(response).to.be.a('object');
       expect(response).to.have.property('attachments');
@@ -93,13 +94,13 @@ describe('slack', () => {
       });
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_S3_BUCKET;
       ctx?.shutdown();
     });
 
     it('should respond with an uploaded graph', async () => {
-      let response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
+      const response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
       expect(response).to.eql(
         'logins - [Upload Error] - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
       );
@@ -107,19 +108,19 @@ describe('slack', () => {
   });
 
   describe('and respond in thread', () => {
-    beforeEach(function () {
+    beforeEach(() => {
       process.env.HUBOT_GRAFANA_USE_THREADS = 1;
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_USE_THREADS;
     });
 
     it('with threaded message', async () => {
-      let responder = new SlackResponder();
-      let resSendResponse = createAwaitableValue();
+      const responder = new SlackResponder();
+      const resSendResponse = createAwaitableValue();
 
-      let res = {
+      const res = {
         message: {
           rawMessage: {
             ts: 42,
@@ -128,14 +129,13 @@ describe('slack', () => {
         send: resSendResponse.set,
       };
 
-      let title = 'logins';
-      let imageUrl = 'https://graf.s3.us-standard.amazonaws.com/grafana/abdcdef0123456789.png';
-      let dashboardUrl = 'https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now';
+      const title = 'logins';
+      const imageUrl = 'https://graf.s3.us-standard.amazonaws.com/grafana/abdcdef0123456789.png';
+      const dashboardUrl = 'https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now';
 
       responder.send(res, title, imageUrl, dashboardUrl);
 
-      let response = await resSendResponse;
-      response = response[0];
+      const [response] = await resSendResponse;
 
       expect(response).to.be.a('object');
       expect(response).to.have.property('attachments');
@@ -174,13 +174,13 @@ describe('slack', () => {
       };
     });
 
-    afterEach(function () {
+    afterEach(() => {
       ctx?.shutdown();
     });
 
     it('should respond with an uploaded graph', async () => {
       await ctx.send('@hubot graf db 97PlYC7Mk:panel-3');
-      let response = await uploadResult;
+      const response = await uploadResult;
 
       expect(response).not.to.be.null;
       expect(response).to.be.of.length(1);
@@ -214,12 +214,12 @@ describe('slack', () => {
       };
     });
 
-    afterEach(function () {
+    afterEach(() => {
       ctx?.shutdown();
     });
 
     it('should respond with an failed message ', async () => {
-      let response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
+      const response = await ctx.sendAndWaitForResponse('@hubot graf db 97PlYC7Mk:panel-3');
       expect(response).to.eql(
         "logins - [Slack files.upload Error: can't upload file] - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now"
       );
@@ -227,18 +227,18 @@ describe('slack', () => {
   });
 
   describe('and Slack upload in thread', () => {
-    beforeEach(function () {
+    beforeEach(() => {
       process.env.HUBOT_GRAFANA_USE_THREADS = 1;
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_USE_THREADS;
     });
 
     it('should respond with a threaded message', async () => {
-      let uploadResult = createAwaitableValue();
+      const uploadResult = createAwaitableValue();
 
-      let robot = {
+      const robot = {
         adapter: {
           client: {
             web: {
@@ -255,7 +255,7 @@ describe('slack', () => {
         },
       };
 
-      let res = {
+      const res = {
         message: {
           rawMessage: {
             ts: 42,
@@ -266,9 +266,9 @@ describe('slack', () => {
         },
       };
 
-      let uploader = new SlackUploader(robot, robot.logger);
-      let title = 'logins';
-      let dashboardUrl = 'https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now';
+      const uploader = new SlackUploader(robot, robot.logger);
+      const title = 'logins';
+      const dashboardUrl = 'https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now';
 
       await uploader.upload(
         res,
@@ -280,7 +280,7 @@ describe('slack', () => {
         dashboardUrl
       );
 
-      let response = await uploadResult;
+      const response = await uploadResult;
 
       expect(response).not.to.be.null;
       expect(response).to.be.of.length(1);
@@ -290,7 +290,7 @@ describe('slack', () => {
       expect(response[0].thread_ts).to.eql(42);
       expect(response[0].channels).to.eql('C1337');
       expect(response[0].title).to.equal('dashboard');
-      expect(response[0].filename).to.eql(title + '.png');
+      expect(response[0].filename).to.eql(`${title}.png`);
       expect(response[0].file).not.to.be.null;
     });
   });

--- a/test/grafana-telegram-test.js
+++ b/test/grafana-telegram-test.js
@@ -14,7 +14,7 @@ describe('telegram', () => {
       });
     });
 
-    afterEach(function () {
+    afterEach(() => {
       delete process.env.HUBOT_GRAFANA_S3_BUCKET;
       ctx?.shutdown();
     });
@@ -33,9 +33,9 @@ describe('telegram', () => {
     // to Mock the Response object.
 
     it('should respond with an uploaded graph', async () => {
-      let uploader = new TelegramUploader();
-      let sendPhotoResult = createAwaitableValue();
-      let res = {
+      const uploader = new TelegramUploader();
+      const sendPhotoResult = createAwaitableValue();
+      const res = {
         sendPhoto: sendPhotoResult.set,
         envelope: {
           room: '#mocha',
@@ -52,7 +52,7 @@ describe('telegram', () => {
         'https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
       );
 
-      var result = await sendPhotoResult;
+      const result = await sendPhotoResult;
 
       expect(result).to.be.of.length(3);
       expect(result[0]).to.eql('#mocha');

--- a/test/grafana-v8-test.js
+++ b/test/grafana-v8-test.js
@@ -14,20 +14,20 @@ describe('grafana v8', () => {
   });
 
   describe('ensure all listeners are registered', () => {
-    it('registers a dashboard listener', function () {
-      let regexes = ctx.robot.listeners.map((x) => x.regex.toString());
+    it('registers a dashboard listener', () => {
+      const regexes = ctx.robot.listeners.map((x) => x.regex.toString());
       expect(regexes).includes(
-        '/^\\s*[@]?hubot[:,]?\\s*(?:(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\\-\\:_]+)(.*)?)/i'
+        '/^\\s*[@]?hubot[:,]?\\s*(?:(?:grafana|graph|graf) (?:dash|dashboard|db) ([A-Za-z0-9\\-:_]+)(.*)?)/i'
       );
     });
 
-    it('registers a list listener', function () {
-      let regexes = ctx.robot.listeners.map((x) => x.regex.toString());
+    it('registers a list listener', () => {
+      const regexes = ctx.robot.listeners.map((x) => x.regex.toString());
       expect(regexes).includes('/^\\s*[@]?hubot[:,]?\\s*(?:(?:grafana|graph|graf) list\\s?(.+)?)/i');
     });
 
-    it('registers a search listener', function () {
-      let regexes = ctx.robot.listeners.map((x) => x.regex.toString());
+    it('registers a search listener', () => {
+      const regexes = ctx.robot.listeners.map((x) => x.regex.toString());
       expect(regexes).includes('/^\\s*[@]?hubot[:,]?\\s*(?:(?:grafana|graph|graf) search (.+))/i');
     });
   });
@@ -41,7 +41,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a list of dashboards', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf list');
+      const response = await ctx.sendAndWaitForResponse('hubot graf list');
       expect(response).to.eql(
         'Available dashboards:\n- 000000016: 1 -  Time series graphs\n- YI95GyqMz: 1 - New Features in v8.0\n- nP8rcffGk: 2 - New Features in v7.4\n- Zb3f4veGk: 2 - Stats\n- 0KapoFkMk: 3 - New Features in  v7.0\n- OhR1ID6Mk: 3 - Table\n- KIhkVD6Gk: 4 -  Gauges\n- Fbp5uPsZk: 4 - New Features in v6.6\n- ktMs4D6Mk: 5 - Bar charts and pie charts\n- ZvPm55mWk: 5 - New Features in v6.3\n- 2ZvPm55mWk: 6 - New Features in v6.2\n- qD-rVv6Mz: 6 - State timeline and Status history\n- fMyjY3R7z: Accessibility\n- 000000052: Advanced Layout\n- 4QfoqzGZk: Alert on multiple series\n- 000000074: Alerting\n- 000000019: Annotations\n- 000000010: Annotations\n- jA2cBIi7z: Annotations Copy\n- 1o-mceRnk: bar chart no room for value\n- vmie2cmWz: Bar Gauge\n- 000000045: Big Dashboard\n- 000000003: Big Dashboard Small\n- 000000079: Big Dashboard Theme\n (and 115 more)'
       );
@@ -57,7 +57,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a list of dashboards with tag', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf list demo');
+      const response = await ctx.sendAndWaitForResponse('hubot graf list demo');
       expect(response).to.eql(
         'Dashboards tagged `demo`:\n- 000000016: 1 -  Time series graphs\n- Zb3f4veGk: 2 - Stats\n- OhR1ID6Mk: 3 - Table\n- KIhkVD6Gk: 4 -  Gauges\n- ktMs4D6Mk: 5 - Bar charts and pie charts\n- qD-rVv6Mz: 6 - State timeline and Status history\n- 000000074: Alerting\n- 000000010: Annotations\n- vmie2cmWz: Bar Gauge\n- 3SWXxreWk: Grafana Dashboard\n- 37Dq903mk: Graph Gradient Area Fills\n- iRY1K9VZk: Lazy Loading\n- 6NmftOxZz: Logs Panel\n- 000000100: Mixed Datasources\n- U_bZIMRMk: Table Panel Showcase\n- 000000056: Templated dynamic dashboard\n- 000000109: The Four Golden Signals\n- 000000167: Threshold example\n- 000000041: Time range override'
       );
@@ -73,7 +73,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a matching dashboard', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf search elasticsearch');
+      const response = await ctx.sendAndWaitForResponse('hubot graf search elasticsearch');
       expect(response).to.eql(
         'Dashboards matching `elasticsearch`:\n- 000000030: ElasticSearch - Custom Templated query\n- VzxU55SWk: Elasticsearch Bar Gauge\n- 000000069: Elasticsearch Derivative\n- 000000014: Elasticsearch Metrics\n- 000000107: Elasticsearch Metrics Filter\n- 000000149: Elasticsearch query filter\n- CknOEXDMk: Elasticsearch Templated\n- uQRtuCoGz: Prometheus, InfluxDB, Elasticsearch DS Trends'
       );
@@ -118,7 +118,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a matching dashboard', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db flowcharting-grafana-play-home');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db flowcharting-grafana-play-home');
       expect(response).to.eql('Try your query again with `97PlYC7Mk` instead of `flowcharting-grafana-play-home`');
     });
   });
@@ -132,7 +132,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a matching dashboard', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:panel-3');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:panel-3');
       expect(response).to.eql(
         'logins: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=3&width=1000&height=500&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=3&fullscreen&from=now-6h&to=now'
       );
@@ -148,7 +148,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a matching dashboard', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3');
       expect(response).to.eql(
         'client side full page load: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=5&width=1000&height=500&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=5&fullscreen&from=now-6h&to=now'
       );
@@ -164,7 +164,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with an error message', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:100');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:100');
       expect(response).to.eql('Could not locate desired panel.');
     });
   });
@@ -184,7 +184,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with the custom image size set in environment', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3');
       expect(response).to.eql(
         'client side full page load: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=5&width=1024&height=768&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=5&fullscreen&from=now-6h&to=now'
       );
@@ -200,7 +200,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a resized image specified in request', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3 width=2500 height=700');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3 width=2500 height=700');
       expect(response).to.eql(
         'client side full page load: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=5&width=2500&height=700&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=5&fullscreen&from=now-6h&to=now'
       );
@@ -216,7 +216,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a resized image specified in request', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3 height=700 width=2500');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3 height=700 width=2500');
       expect(response).to.eql(
         'client side full page load: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=5&width=2500&height=700&from=now-6h&to=now - https://play.grafana.org/d/97PlYC7Mk/?panelId=5&fullscreen&from=now-6h&to=now'
       );
@@ -232,7 +232,9 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a resized image specified in request', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 97PlYC7Mk:3 from=1705569109372 to=1705572545230');
+      const response = await ctx.sendAndWaitForResponse(
+        'hubot graf db 97PlYC7Mk:3 from=1705569109372 to=1705572545230'
+      );
       expect(response).to.eql(
         'client side full page load: https://play.grafana.org/render/d-solo/97PlYC7Mk/?panelId=5&width=1000&height=500&from=1705569109372&to=1705572545230 - https://play.grafana.org/d/97PlYC7Mk/?panelId=5&fullscreen&from=1705569109372&to=1705572545230'
       );
@@ -248,7 +250,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a templated graph', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf db 000000091:graph server=backend_01 now-6h');
+      const response = await ctx.sendAndWaitForResponse('hubot graf db 000000091:graph server=backend_01 now-6h');
       expect(response).to.eql(
         'Graph for backend_01: https://play.grafana.org/render/d-solo/000000091/?panelId=1&width=1000&height=500&from=now-6h&to=now&var-server=backend_01 - https://play.grafana.org/d/000000091/?panelId=1&fullscreen&from=now-6h&to=now&var-server=backend_01'
       );
@@ -264,7 +266,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a list of alerts', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf alerts');
+      const response = await ctx.sendAndWaitForResponse('hubot graf alerts');
       expect(response).to.eql(
         'All alerts:\n- *API Error  / 1min alert* (2): `no_data`\n  last state change: 2021-06-05T13:18:08Z\n- *Customer Reviews alert* (11): `ok`\n  last state change: 2021-06-09T14:49:08Z\n- *Dashboard Loads Peaking* (4): `alerting`\n  last state change: 2021-06-09T14:36:04Z\n- *Metric Requests Peaking* (1): `alerting`\n  last state change: 2021-06-09T14:04:01Z\n- *Multi series alerting* (29): `alerting`\n  last state change: 2021-06-09T09:51:52Z\n- *Payments Completed/s alert* (10): `ok`\n  last state change: 2021-06-06T03:57:16Z\n- *Payments Completed/s alert* (12): `ok`\n  last state change: 2021-06-09T10:56:30Z\n- *Request Time Average < 190ms alert* (3): `ok`\n  last state change: 2021-06-09T09:41:06Z\n- *Selected Servers alert* (7): `alerting`\n  last state change: 2020-10-31T13:30:08Z\n- *Selected Servers alert* (8): `alerting`\n  last state change: 2020-11-11T13:30:20Z\n- *Wind Farm - Total power is low* (30): `ok`\n  last state change: 2021-03-17T17:57:52Z'
       );
@@ -280,7 +282,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a successful paused response', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf pause alert 1');
+      const response = await ctx.sendAndWaitForResponse('hubot graf pause alert 1');
       expect(response).to.eql('alert paused');
     });
   });
@@ -294,7 +296,7 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a successful un-paused response', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf unpause alert 1');
+      const response = await ctx.sendAndWaitForResponse('hubot graf unpause alert 1');
       expect(response).to.eql('alert un-paused');
     });
   });
@@ -313,12 +315,8 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a successful paused response', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf pause all alerts');
-      expect(response).to.eql(
-        "Successfully tried to pause *1* alerts.\n" +
-        "*Success: 1*\n" +
-        "*Errored: 0*"
-      );
+      const response = await ctx.sendAndWaitForResponse('hubot graf pause all alerts');
+      expect(response).to.eql('Successfully tried to pause *1* alerts.\n' + '*Success: 1*\n' + '*Errored: 0*');
     });
   });
 
@@ -336,12 +334,8 @@ describe('grafana v8', () => {
     });
 
     it('hubot should respond with a successful un-paused response', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf unpause all alerts');
-      expect(response).to.eql(
-        "Successfully tried to unpause *1* alerts.\n" +
-        "*Success: 1*\n" +
-        "*Errored: 0*"
-      );
+      const response = await ctx.sendAndWaitForResponse('hubot graf unpause all alerts');
+      expect(response).to.eql('Successfully tried to unpause *1* alerts.\n' + '*Success: 1*\n' + '*Errored: 0*');
     });
   });
 });

--- a/test/kiosk-test.js
+++ b/test/kiosk-test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { TestBotContext, createTestBot } = require('./common/TestBot');
 
-describe('retrieve dashboard graphs', function () {
+describe('retrieve dashboard graphs', () => {
   /** @type {TestBotContext} */
   let ctx;
 
@@ -18,7 +18,7 @@ describe('retrieve dashboard graphs', function () {
   });
 
   it('should respond with a single graph in kiosk mode', async () => {
-    let response = await ctx.sendAndWaitForResponse('hubot graf db 000000091 kiosk');
+    const response = await ctx.sendAndWaitForResponse('hubot graf db 000000091 kiosk');
     expect(response).to.eql(
       'Templating showcase: https://play.grafana.org/render/d/000000091/?kiosk&autofitpanels&width=1000&height=500&from=now-6h&to=now - https://play.grafana.org/d/000000091/?from=now-6h&to=now'
     );

--- a/test/per-room-configuration-test.js
+++ b/test/per-room-configuration-test.js
@@ -10,55 +10,54 @@ describe('per room configuration', () => {
     ctx = await createTestBot();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     delete process.env.HUBOT_GRAFANA_PER_ROOM;
     ctx?.shutdown();
   });
 
   describe('ensure configuration listener is registered', () =>
-    it('register configuration listener', function () {
-      let regexes = ctx.robot.listeners.map((x) => x.regex.toString());
+    it('register configuration listener', () => {
+      const regexes = ctx.robot.listeners.map((x) => x.regex.toString());
       expect(regexes).includes('/^\\s*[@]?hubot[:,]?\\s*(?:(?:grafana|graph|graf) set (host|api_key) (.+))/i');
-    })
-  );
+    }));
 
   describe('ask hubot to configure grafana host', () => {
     it('hubot should respond it has configured the host', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf set host https://play.grafana.org');
+      const response = await ctx.sendAndWaitForResponse('hubot graf set host https://play.grafana.org');
       expect(response).to.eql('Value set for host');
-    })
+    });
   });
 
   describe('ask hubot to configure grafana api_key', () => {
     it('hubot should respond it has configured the api_key', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf set api_key AABBCC');
+      const response = await ctx.sendAndWaitForResponse('hubot graf set api_key AABBCC');
       expect(response).to.eql('Value set for api_key');
-    })
+    });
   });
 
   describe('ask hubot to list dashboards filterd by tag', () => {
     it('hubot should respond that grafana endpoint is not configured', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf list demo');
+      const response = await ctx.sendAndWaitForResponse('hubot graf list demo');
       expect(response).to.eql('No Grafana endpoint configured.');
-    })
-  })
+    });
+  });
 
   describe('ask hubot to configure host and then list dashboards filterd by tag', () => {
     beforeEach(() => {
-      ctx.nock('https://play.grafana.org')
+      ctx
+        .nock('https://play.grafana.org')
         .get('/api/search?type=dash-db&tag=demo')
         .replyWithFile(200, `${__dirname}/fixtures/v8/search-tag.json`);
     });
 
     it('hubot should respond that grafana is configured and then with a list of dashboards with tag', async () => {
+      const response1 = await ctx.sendAndWaitForResponse('hubot graf set host https://play.grafana.org');
+      expect(response1).to.eql('Value set for host');
 
-      let response1 = await ctx.sendAndWaitForResponse('hubot graf set host https://play.grafana.org');
-      expect(response1).to.eql('Value set for host')
-
-      let response2 = await ctx.sendAndWaitForResponse('hubot graf list demo');
-      expect(response2).to.eql('Dashboards tagged `demo`:\n- 000000016: 1 -  Time series graphs\n- Zb3f4veGk: 2 - Stats\n- OhR1ID6Mk: 3 - Table\n- KIhkVD6Gk: 4 -  Gauges\n- ktMs4D6Mk: 5 - Bar charts and pie charts\n- qD-rVv6Mz: 6 - State timeline and Status history\n- 000000074: Alerting\n- 000000010: Annotations\n- vmie2cmWz: Bar Gauge\n- 3SWXxreWk: Grafana Dashboard\n- 37Dq903mk: Graph Gradient Area Fills\n- iRY1K9VZk: Lazy Loading\n- 6NmftOxZz: Logs Panel\n- 000000100: Mixed Datasources\n- U_bZIMRMk: Table Panel Showcase\n- 000000056: Templated dynamic dashboard\n- 000000109: The Four Golden Signals\n- 000000167: Threshold example\n- 000000041: Time range override');
-
+      const response2 = await ctx.sendAndWaitForResponse('hubot graf list demo');
+      expect(response2).to.eql(
+        'Dashboards tagged `demo`:\n- 000000016: 1 -  Time series graphs\n- Zb3f4veGk: 2 - Stats\n- OhR1ID6Mk: 3 - Table\n- KIhkVD6Gk: 4 -  Gauges\n- ktMs4D6Mk: 5 - Bar charts and pie charts\n- qD-rVv6Mz: 6 - State timeline and Status history\n- 000000074: Alerting\n- 000000010: Annotations\n- vmie2cmWz: Bar Gauge\n- 3SWXxreWk: Grafana Dashboard\n- 37Dq903mk: Graph Gradient Area Fills\n- iRY1K9VZk: Lazy Loading\n- 6NmftOxZz: Logs Panel\n- 000000100: Mixed Datasources\n- U_bZIMRMk: Table Panel Showcase\n- 000000056: Templated dynamic dashboard\n- 000000109: The Four Golden Signals\n- 000000167: Threshold example\n- 000000041: Time range override'
+      );
     });
   });
 });
-

--- a/test/static-configuration-test.js
+++ b/test/static-configuration-test.js
@@ -14,21 +14,21 @@ describe('static configuration', () => {
   });
 
   describe('ensure configuration listener is registered', () =>
-    it('register configuration listener', function () {
-      let regexes = ctx.robot.listeners.map((x) => x.regex.toString());
+    it('register configuration listener', () => {
+      const regexes = ctx.robot.listeners.map((x) => x.regex.toString());
       expect(regexes).includes('/^\\s*[@]?hubot[:,]?\\s*(?:(?:grafana|graph|graf) set (host|api_key) (.+))/i');
     }));
 
   describe('ask hubot to configure grafana host', () => {
     it('hubot should respond it cannot configure the host', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf set host https://play.grafana.org');
+      const response = await ctx.sendAndWaitForResponse('hubot graf set host https://play.grafana.org');
       expect(response).to.eql('Set HUBOT_GRAFANA_PER_ROOM=1 to use multiple configurations.');
     });
   });
 
   describe('ask hubot to configure grafana api_key', () => {
     it('hubot should respond it cannot configure the api_key', async () => {
-      let response = await ctx.sendAndWaitForResponse('hubot graf set api_key AABBCC');
+      const response = await ctx.sendAndWaitForResponse('hubot graf set api_key AABBCC');
       expect(response).to.eql('Set HUBOT_GRAFANA_PER_ROOM=1 to use multiple configurations.');
     });
   });

--- a/test/timezone-test.js
+++ b/test/timezone-test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { TestBotContext, createTestBot } = require('./common/TestBot');
 
-describe('retrieve graphs by timezone', function () {
+describe('retrieve graphs by timezone', () => {
   /** @type {TestBotContext} */
   let ctx;
 
@@ -20,14 +20,14 @@ describe('retrieve graphs by timezone', function () {
   });
 
   it('should respond with default timezone set', async () => {
-    let response = await ctx.sendAndWaitForResponse('hubot graf db 000000091:table server=backend_01 now-6h');
+    const response = await ctx.sendAndWaitForResponse('hubot graf db 000000091:table server=backend_01 now-6h');
     expect(response).to.eql(
       'Table: https://play.grafana.org/render/d-solo/000000091/?panelId=2&width=1000&height=500&from=now-6h&to=now&var-server=backend_01&tz=America%2FChicago - https://play.grafana.org/d/000000091/?panelId=2&fullscreen&from=now-6h&to=now&var-server=backend_01'
     );
   });
 
   it('should respond with requested timezone set', async () => {
-    let response = await ctx.sendAndWaitForResponse(
+    const response = await ctx.sendAndWaitForResponse(
       'hubot graf db 000000091:table server=backend_01 now-6h tz=Europe/Amsterdam'
     );
     expect(response).to.eql(


### PR DESCRIPTION
## Summary
- Replace `airbnb-base` with Prettier (formatting) + `eslint:recommended` + `eslint-plugin-import` (correctness). `airbnb-base` was fighting this codebase's established patterns (`for...of`, base-class no-ops, API-shaped snake_case names like `thread_ts`/`channel_id`) more than it was catching real bugs, and its formatting opinions (`max-len`, `operator-linebreak`, `no-plusplus`, etc.) added churn without value.
- Fix two real bugs in `RocketChatUploader` surfaced by linting: an undefined-global reference (`rocketchat_url` instead of `this.rocketchat_url`) and a bare `post(...)` call that should have been `this.post(...)` — both would throw at runtime. Also fixed a dead error-message comparison (`ex == 'Could not authenticate.'` against an `Error` object, which never matched due to `Error#toString()`'s `"Error: "` prefix).
- Reformat `src/` and `test/` with Prettier for consistent style.
- Wire `npm run lint` into the Husky pre-commit hook so lint failures block commits going forward.

## Test plan
- [x] `npm test` (63 passing)
- [x] `npm run lint` (clean)